### PR TITLE
Hybrid cuda version persistent threads

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -38,6 +38,15 @@
             }
         },
         {
+            "name": "vs-release",
+            "inherits": "base",
+            "hidden": false,
+            "generator": "Visual Studio 17 2022",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release"
+            }
+        },
+        {
             "name": "linux-debug",
             "inherits": "base",
             "hidden": false,

--- a/assets/shaders/hybrid_glsl/cylinder_classify_old.compute
+++ b/assets/shaders/hybrid_glsl/cylinder_classify_old.compute
@@ -1,0 +1,453 @@
+#version 460
+#extension GL_ARB_gpu_shader_int64 : require
+#extension GL_EXT_shader_atomic_int64 : require
+
+// =============================================================================
+// cylinder_classify.compute - Cylinder Classification with Depth Priority
+// =============================================================================
+//
+// This shader classifies cylinders with depth-aware tile assignment.
+// When a tile overflows, closer entities replace farther ones.
+//
+// For each cylinder:
+//   1. Frustum culling
+//   2. BBox extraction
+//   3. Classification by area:
+//      - SMALL: Store index in small cylinder list
+//      - LARGE: Store in tiles with depth priority
+//
+// Dispatch: (cylinderCount / 256, 1, 1)
+// =============================================================================
+
+layout(local_size_x = 256) in;
+
+// -----------------------------------------------------------------------------
+// Constants
+// -----------------------------------------------------------------------------
+
+#define TILE_SIZE 16
+#define TILE_SIZE_SHIFT 4
+#define MAX_ENTITIES_PER_TILE 256
+
+// -----------------------------------------------------------------------------
+// Tile Bindings
+// -----------------------------------------------------------------------------
+
+layout(std430, binding = 3) buffer TileCylinderCounts {
+    uint tileCylinderCounts[];
+};
+
+layout(std430, binding = 5) buffer TileCylinderIndices {
+    uint tileCylinderIndices[];  // [tileIndex * MAX_ENTITIES_PER_TILE + localIndex]
+};
+
+// Depth data for priority (uint = floatBitsToUint for atomicCompSwap)
+layout(std430, binding = 15) buffer TileCylinderDepthsUint {
+    uint tileCylinderDepthsUint[];  // [tileIndex * MAX_ENTITIES_PER_TILE + slot]
+};
+
+// Max depth cache per tile: uint64 = (depthBits << 32) | slot, updated with atomicMax
+layout(std430, binding = 17) buffer TileCylinderMaxCache {
+    uint64_t tileCylinderMaxCache[];  // [tileIndex]
+};
+
+// -----------------------------------------------------------------------------
+// Small Cylinder Output
+// -----------------------------------------------------------------------------
+
+layout(std430, binding = 11) buffer SmallCylinderCounter {
+    uint smallCylinderCount;
+};
+
+layout(std430, binding = 13) buffer SmallCylinderIndices {
+    uint smallCylinderIndices[];  // List of cylinder indices that are "small"
+};
+
+// -----------------------------------------------------------------------------
+// Input Bindings
+// -----------------------------------------------------------------------------
+
+struct Cylinder {
+    vec4 pa_r;  // Point A (xyz) + radius (w)
+    vec4 pb_r;  // Point B (xyz), w unused
+};
+
+layout(std430, binding = 7) buffer CylinderBuffer {
+    Cylinder cylinders[];
+};
+
+// -----------------------------------------------------------------------------
+// Uniforms
+// -----------------------------------------------------------------------------
+
+uniform mat4 view;
+uniform mat4 proj;
+
+uniform vec4 frustumTopFace;
+uniform vec4 frustumBottomFace;
+uniform vec4 frustumRightFace;
+uniform vec4 frustumLeftFace;
+uniform vec4 frustumFarFace;
+uniform vec4 frustumNearFace;
+
+uniform ivec2 screenResolution;
+
+uniform int cylinderCount;
+uniform int smallEntityThreshold;
+uniform int tilesX;
+uniform int tilesY;
+uniform vec3 cameraPos;
+
+// -----------------------------------------------------------------------------
+// Frustum Culling
+// -----------------------------------------------------------------------------
+
+struct BBox3D
+{
+    vec3 mMin;
+    vec3 mMax;
+};
+
+bool isOnOrForwardPlaneAABB(vec4 plane, BBox3D bbox) 
+{
+    vec3 negativeVertex = bbox.mMin;
+    vec3 normal = plane.xyz;
+    float distance = plane.w;
+
+    if (normal.x >= 0) negativeVertex.x = bbox.mMax.x;
+        else negativeVertex.x = bbox.mMin.x;
+
+    if (normal.y >= 0) negativeVertex.y = bbox.mMax.y;
+        else negativeVertex.y = bbox.mMin.y;
+
+    if (normal.z >= 0) negativeVertex.z = bbox.mMax.z;
+        else negativeVertex.z = bbox.mMin.z;
+
+    return dot(normal, negativeVertex) - distance >= 0;
+}
+
+bool isCylinderInFrustum(vec3 pa, vec3 pb, float radius) {
+    // Use bounding sphere for cylinder
+    vec3 a = pb - pa;
+    vec3 e = radius*sqrt( max(1.0f - a*(a/dot(a,a)), 0.0) );
+    BBox3D bbox3d = BBox3D(min( pa, pb ) - e, max( pa, pb ) + e);
+
+    return isOnOrForwardPlaneAABB(frustumLeftFace, bbox3d) &&
+           isOnOrForwardPlaneAABB(frustumRightFace, bbox3d) &&
+           isOnOrForwardPlaneAABB(frustumFarFace, bbox3d) &&
+           isOnOrForwardPlaneAABB(frustumNearFace, bbox3d) &&
+           isOnOrForwardPlaneAABB(frustumTopFace, bbox3d) &&
+           isOnOrForwardPlaneAABB(frustumBottomFace, bbox3d);
+}
+
+// -----------------------------------------------------------------------------
+// BBox Computation
+// -----------------------------------------------------------------------------
+
+void getCylinderBbox(out vec2 projectedPoints[4], vec3 pa, vec3 pb, vec3 center, 
+    float cylRadius)
+{
+    // Cylinder axis
+    const vec3 z = normalize(pb - pa);
+
+    // Find orthonormal x,y axes orthogonal to cylinder axis
+    vec3 x = normalize(cross(center, z));
+    vec3 y = normalize(cross(x, z)); // make full basis
+
+    // Compute impostor construction vectors.
+    const float dV0 = length( pa );
+    const float dV1 = length( pb );
+
+    const float sinAngle = cylRadius / dV0;
+    float		angle	 = asin( sinAngle );
+    const vec3	y1		 = y * cylRadius;
+    const vec3	x2		 = x * cylRadius * cos( angle );
+    const vec3	y2		 = y1 * sinAngle;
+    angle				 = asin( cylRadius / dV1 );
+    const vec3 x3		 = x * ( dV1 - cylRadius ) * tan( angle );
+
+    // Compute impostors vertices.
+    const vec3 v1 = pa - x2 + y2;
+    const vec3 v2 = pa + x2 + y2;
+    const vec3 v3 = pb - x3 + y1;
+    const vec3 v4 = pb + x3 + y1;
+
+    const vec4 v1Proj = proj * vec4(v1, 1.0f);
+    const vec4 v2Proj = proj * vec4(v2, 1.0f);
+    const vec4 v3Proj = proj * vec4(v3, 1.0f);
+    const vec4 v4Proj = proj * vec4(v4, 1.0f);
+
+    vec3 ndcv1Proj = vec3(v1Proj.x / v1Proj.w, v1Proj.y / v1Proj.w, v1Proj.z / v1Proj.w);
+    vec3 ndcv2Proj = vec3(v2Proj.x / v2Proj.w, v2Proj.y / v2Proj.w, v2Proj.z / v2Proj.w);
+    vec3 ndcv3Proj = vec3(v3Proj.x / v3Proj.w, v3Proj.y / v3Proj.w, v3Proj.z / v3Proj.w);
+    vec3 ndcv4Proj = vec3(v4Proj.x / v4Proj.w, v4Proj.y / v4Proj.w, v4Proj.z / v4Proj.w);
+
+    projectedPoints[0] = vec2(ndcv1Proj);
+    projectedPoints[1] = vec2(ndcv2Proj);
+    projectedPoints[2] = vec2(ndcv4Proj);
+    projectedPoints[3] = vec2(ndcv3Proj);
+        
+}
+
+// -----------------------------------------------------------------------------
+// Quad-Tile Intersection Helpers
+// -----------------------------------------------------------------------------
+
+// Cross product of 2D vectors (returns scalar z component)
+float cross2D(vec2 a, vec2 b) {
+    return a.x * b.y - a.y * b.x;
+}
+
+// Check if point is inside convex quadrilateral (using cross products)
+// Assumes quad vertices are in order (either CW or CCW)
+bool pointInQuad(vec2 p, vec2 q0, vec2 q1, vec2 q2, vec2 q3) {
+    float c0 = cross2D(q1 - q0, p - q0);
+    float c1 = cross2D(q2 - q1, p - q1);
+    float c2 = cross2D(q3 - q2, p - q2);
+    float c3 = cross2D(q0 - q3, p - q3);
+    
+    // All same sign means inside (works for CW or CCW)
+    return (c0 >= 0 && c1 >= 0 && c2 >= 0 && c3 >= 0) ||
+           (c0 <= 0 && c1 <= 0 && c2 <= 0 && c3 <= 0);
+}
+
+// Check if line segment (a,b) intersects line segment (c,d)
+bool segmentsIntersect(vec2 a, vec2 b, vec2 c, vec2 d) {
+    vec2 ab = b - a;
+    vec2 cd = d - c;
+    vec2 ac = c - a;
+    
+    float denom = cross2D(ab, cd);
+    if (abs(denom) < 1e-6) return false; // Parallel
+    
+    float t = cross2D(ac, cd) / denom;
+    float u = cross2D(ac, ab) / denom;
+    
+    return t >= 0.0 && t <= 1.0 && u >= 0.0 && u <= 1.0;
+}
+
+// Check if tile (axis-aligned box) intersects with quadrilateral
+bool tileIntersectsQuad(int tileX, int tileY, vec2 q0, vec2 q1, vec2 q2, vec2 q3) {
+    // Tile bounds in pixels
+    float tileMinX = float(tileX * TILE_SIZE);
+    float tileMinY = float(tileY * TILE_SIZE);
+    float tileMaxX = tileMinX + float(TILE_SIZE);
+    float tileMaxY = tileMinY + float(TILE_SIZE);
+    
+    // Tile corners
+    vec2 t0 = vec2(tileMinX, tileMinY);
+    vec2 t1 = vec2(tileMaxX, tileMinY);
+    vec2 t2 = vec2(tileMaxX, tileMaxY);
+    vec2 t3 = vec2(tileMinX, tileMaxY);
+    
+    // Test 1: Any tile corner inside quad?
+    if (pointInQuad(t0, q0, q1, q2, q3)) return true;
+    if (pointInQuad(t1, q0, q1, q2, q3)) return true;
+    if (pointInQuad(t2, q0, q1, q2, q3)) return true;
+    if (pointInQuad(t3, q0, q1, q2, q3)) return true;
+    
+    // Test 2: Any quad corner inside tile?
+    if (q0.x >= tileMinX && q0.x <= tileMaxX && q0.y >= tileMinY && q0.y <= tileMaxY) return true;
+    if (q1.x >= tileMinX && q1.x <= tileMaxX && q1.y >= tileMinY && q1.y <= tileMaxY) return true;
+    if (q2.x >= tileMinX && q2.x <= tileMaxX && q2.y >= tileMinY && q2.y <= tileMaxY) return true;
+    if (q3.x >= tileMinX && q3.x <= tileMaxX && q3.y >= tileMinY && q3.y <= tileMaxY) return true;
+    
+    // Quad edge 0: q0 -> q1
+    if (segmentsIntersect(q0, q1, t0, t1)) return true;
+    if (segmentsIntersect(q0, q1, t1, t2)) return true;
+    if (segmentsIntersect(q0, q1, t2, t3)) return true;
+    if (segmentsIntersect(q0, q1, t3, t0)) return true;
+    
+    // Quad edge 1: q1 -> q2
+    if (segmentsIntersect(q1, q2, t0, t1)) return true;
+    if (segmentsIntersect(q1, q2, t1, t2)) return true;
+    if (segmentsIntersect(q1, q2, t2, t3)) return true;
+    if (segmentsIntersect(q1, q2, t3, t0)) return true;
+    
+    // Quad edge 2: q2 -> q3
+    if (segmentsIntersect(q2, q3, t0, t1)) return true;
+    if (segmentsIntersect(q2, q3, t1, t2)) return true;
+    if (segmentsIntersect(q2, q3, t2, t3)) return true;
+    if (segmentsIntersect(q2, q3, t3, t0)) return true;
+    
+    // Quad edge 3: q3 -> q0
+    if (segmentsIntersect(q3, q0, t0, t1)) return true;
+    if (segmentsIntersect(q3, q0, t1, t2)) return true;
+    if (segmentsIntersect(q3, q0, t2, t3)) return true;
+    if (segmentsIntersect(q3, q0, t3, t0)) return true;
+    
+    return false;
+}
+
+// -----------------------------------------------------------------------------
+// Tile Assignment for Large Cylinders (with depth priority)
+// -----------------------------------------------------------------------------
+
+void assignToTileWithPriority(uint cylinderIndex, int tileIndex, float depth) {
+    uint depthBits = floatBitsToUint(depth);
+    
+    // Try to get a slot
+    uint slot = atomicAdd(tileCylinderCounts[tileIndex], 1u);
+    
+    if (slot < MAX_ENTITIES_PER_TILE) {
+        // Normal insertion - there's space
+        uint idx = tileIndex * MAX_ENTITIES_PER_TILE + slot;
+        tileCylinderIndices[idx] = cylinderIndex;
+        tileCylinderDepthsUint[idx] = depthBits;
+        
+        // Update max cache atomically: packed = (depthBits << 32) | slot
+        uint64_t packed = (uint64_t(depthBits) << 32) | uint64_t(slot);
+        atomicMax(tileCylinderMaxCache[tileIndex], packed);
+    } else {
+        // Overflow - revert the count increment
+        atomicAdd(tileCylinderCounts[tileIndex], -1u);
+        
+        // Read cache (single 64-bit load is atomic)
+        uint64_t cacheVal = tileCylinderMaxCache[tileIndex];
+        uint maxDepthBits = uint(cacheVal >> 32);
+        uint maxSlot = uint(cacheVal & 0xFFFFFFFFu);
+        
+        // Only replace if we're closer (smaller depth) and slot is valid
+        if (depthBits < maxDepthBits && maxSlot < MAX_ENTITIES_PER_TILE) {
+            uint idx = tileIndex * MAX_ENTITIES_PER_TILE + maxSlot;
+            
+            // Atomically claim the slot: only one thread wins
+            uint oldDepthBits = atomicCompSwap(tileCylinderDepthsUint[idx], maxDepthBits, depthBits);
+            
+            if (oldDepthBits == maxDepthBits) {
+                // We won - write the index
+                tileCylinderIndices[idx] = cylinderIndex;
+                
+                // Update cache with atomicMax (our packed value)
+                uint64_t ourPacked = (uint64_t(depthBits) << 32) | uint64_t(maxSlot);
+                atomicMax(tileCylinderMaxCache[tileIndex], ourPacked);
+            }
+        }
+    }
+}
+
+void assignToTiles(uint cylinderIndex, vec2 q0, vec2 q1, vec2 q2, vec2 q3, float depth) {
+    // First compute AABB of the quad to limit tile iteration
+    vec2 minP = min(min(q0, q1), min(q2, q3));
+    vec2 maxP = max(max(q0, q1), max(q2, q3));
+    
+    int tileMinX = int(floor(minP.x)) >> TILE_SIZE_SHIFT;
+    int tileMinY = int(floor(minP.y)) >> TILE_SIZE_SHIFT;
+    int tileMaxX = int(ceil(maxP.x)) >> TILE_SIZE_SHIFT;
+    int tileMaxY = int(ceil(maxP.y)) >> TILE_SIZE_SHIFT;
+    
+    tileMinX = clamp(tileMinX, 0, tilesX - 1);
+    tileMinY = clamp(tileMinY, 0, tilesY - 1);
+    tileMaxX = clamp(tileMaxX, 0, tilesX - 1);
+    tileMaxY = clamp(tileMaxY, 0, tilesY - 1);
+    
+    // For each tile in AABB, assign with depth priority
+    for (int ty = tileMinY; ty <= tileMaxY; ty++) {
+        for (int tx = tileMinX; tx <= tileMaxX; tx++) {
+            int tileIndex = ty * tilesX + tx;
+            assignToTileWithPriority(cylinderIndex, tileIndex, depth);
+        }
+    }
+}
+
+// Compute area of quadrilateral using shoelace formula
+float quadArea(vec2 q0, vec2 q1, vec2 q2, vec2 q3) {
+    return 0.5 * abs(
+        (q0.x * q1.y - q1.x * q0.y) +
+        (q1.x * q2.y - q2.x * q1.y) +
+        (q2.x * q3.y - q3.x * q2.y) +
+        (q3.x * q0.y - q0.x * q3.y)
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Main
+// -----------------------------------------------------------------------------
+
+void main() {
+    uint cylIndex = gl_GlobalInvocationID.x;
+    
+    if (cylIndex >= cylinderCount) {
+        return;
+    }
+    
+    Cylinder cyl = cylinders[cylIndex];
+    vec3 pa = cyl.pa_r.xyz;
+    vec3 pb = cyl.pb_r.xyz;
+    float radius = cyl.pa_r.w;
+    
+    // =========================================================================
+    // STAGE 1: Frustum Culling
+    // =========================================================================
+    
+    if (!isCylinderInFrustum(pa, pb, radius)) {
+        return;
+    }
+    
+    // =========================================================================
+    // STAGE 2: BBox Extraction
+    // =========================================================================
+
+    vec3 camSpaceCylA = vec3(view * vec4(pa, 1.0f));
+    vec3 camSpaceCylB = vec3(view * vec4(pb, 1.0f));
+
+    vec3 camImpPosA, camImpPosB;
+    if ( camSpaceCylA.z < camSpaceCylB.z )
+	{
+		camImpPosA = camSpaceCylB;
+		camImpPosB = camSpaceCylA;
+	}
+	else
+	{
+		camImpPosA = camSpaceCylA;
+		camImpPosB = camSpaceCylB;
+	}
+
+    vec3 center = normalize( ( camImpPosA + camImpPosB ) * 0.5f );
+    vec2 projectedPoints[4];
+    getCylinderBbox(projectedPoints, camImpPosA, camImpPosB, center, radius);
+    
+    // Convert NDC to screen coordinates
+    for (int i = 0; i < 4; i++) 
+    {
+        projectedPoints[i].x = (projectedPoints[i].x * 0.5f + 0.5f) * float(screenResolution.x);
+        projectedPoints[i].y = (projectedPoints[i].y * 0.5f + 0.5f) * float(screenResolution.y);
+    }
+    
+    // Clamp to screen bounds
+    for (int i = 0; i < 4; i++) {
+        projectedPoints[i] = clamp(projectedPoints[i], vec2(0.0), vec2(screenResolution));
+    }
+    
+    // Compute area of the rotated quad
+    float area = quadArea(projectedPoints[0], projectedPoints[1], 
+                          projectedPoints[2], projectedPoints[3]);
+    
+    // Skip if degenerate
+    if (area < 1.0) {
+        return;
+    }
+    
+    // =========================================================================
+    // STAGE 3: Compute Depth (distance from camera to cylinder center)
+    // =========================================================================
+    
+    vec3 cylinderCenter = (pa + pb) * 0.5;
+    float depth = distance(cameraPos, cylinderCenter);
+    
+    // =========================================================================
+    // STAGE 4: Classification
+    // =========================================================================
+    
+    if (area <= float(smallEntityThreshold)) {
+        // SMALL: Add to small cylinder list
+        uint slot = atomicAdd(smallCylinderCount, 1u);
+        smallCylinderIndices[slot] = cylIndex;
+    } else {
+        // LARGE: Assign to overlapping tiles with depth priority
+        assignToTiles(cylIndex, 
+                      projectedPoints[0], projectedPoints[1], 
+                      projectedPoints[2], projectedPoints[3],
+                      depth);
+    }
+}

--- a/assets/shaders/hybrid_glsl/screen_clear_old.compute
+++ b/assets/shaders/hybrid_glsl/screen_clear_old.compute
@@ -1,0 +1,109 @@
+#version 460
+#extension GL_ARB_gpu_shader_int64 : require
+#extension GL_EXT_shader_atomic_int64 : require
+
+// =============================================================================
+// screen_clear.compute - Clear framebuffer, depth buffer, and all counters
+// =============================================================================
+//
+// Dispatch: (screenWidth/16, screenHeight/16, 1)
+// =============================================================================
+
+layout(local_size_x = 16, local_size_y = 16) in;
+
+// -----------------------------------------------------------------------------
+// Output Bindings
+// -----------------------------------------------------------------------------
+
+layout(rgba8, binding = 0) uniform image2D outputImage;
+
+layout(std430, binding = 1) buffer DepthBuffer {
+    uint depthBuffer[];
+};
+
+// Tile counters
+layout(std430, binding = 2) buffer TileSphereCounts {
+    uint tileSphereCounts[];
+};
+
+layout(std430, binding = 3) buffer TileCylinderCounts {
+    uint tileCylinderCounts[];
+};
+
+// Small entity counters (single value each)
+layout(std430, binding = 10) buffer SmallSphereCounter {
+    uint smallSphereCount;
+};
+
+layout(std430, binding = 11) buffer SmallCylinderCounter {
+    uint smallCylinderCount;
+};
+
+// Tile depth data for entities (uint = floatBitsToUint)
+layout(std430, binding = 14) buffer TileSphereDepthsUint {
+    uint tileSphereDepthsUint[];
+};
+
+layout(std430, binding = 15) buffer TileCylinderDepthsUint {
+    uint tileCylinderDepthsUint[];
+};
+
+// Tile max depth cache: uint64 = (depthBits << 32) | slot
+layout(std430, binding = 16) buffer TileSphereMaxCache {
+    uint64_t tileSphereMaxCache[];  // [tileIndex]
+};
+
+layout(std430, binding = 17) buffer TileCylinderMaxCache {
+    uint64_t tileCylinderMaxCache[];  // [tileIndex]
+};
+
+// -----------------------------------------------------------------------------
+// Uniforms
+// -----------------------------------------------------------------------------
+
+uniform ivec2 screenResolution;
+uniform float farPlane;
+uniform int tilesX;
+uniform int tilesY;
+uniform int maxEntitiesPerTile;
+
+// -----------------------------------------------------------------------------
+// Main
+// -----------------------------------------------------------------------------
+
+void main() {
+    ivec2 pixel = ivec2(gl_GlobalInvocationID.xy);
+    
+    // Clear color to black
+    if (pixel.x < screenResolution.x && pixel.y < screenResolution.y) {
+        imageStore(outputImage, pixel, vec4(0.0, 0.0, 0.0, 1.0));
+        
+        // Clear depth to far plane
+        int pixelIndex = pixel.y * screenResolution.x + pixel.x;
+        depthBuffer[pixelIndex] = floatBitsToUint(farPlane);
+    }
+    
+    // Reset tile counters and caches (first thread of each tile)
+    if (gl_LocalInvocationID.x == 0 && gl_LocalInvocationID.y == 0) {
+        int tileX = int(gl_WorkGroupID.x);
+        int tileY = int(gl_WorkGroupID.y);
+        
+        if (tileX < tilesX && tileY < tilesY) {
+            int tileIndex = tileY * tilesX + tileX;
+            
+            // Reset counters
+            tileSphereCounts[tileIndex] = 0;
+            tileCylinderCounts[tileIndex] = 0;
+            
+            // Reset max cache to 0 (no entity)
+            tileSphereMaxCache[tileIndex] = 0UL;
+            tileCylinderMaxCache[tileIndex] = 0UL;
+        }
+        
+        // Reset small entity counters (only first work group)
+        if (gl_WorkGroupID.x == 0 && gl_WorkGroupID.y == 0) {
+            smallSphereCount = 0;
+            smallCylinderCount = 0;
+        }
+    }
+}

--- a/assets/shaders/hybrid_glsl/sphere_classify_old.compute
+++ b/assets/shaders/hybrid_glsl/sphere_classify_old.compute
@@ -1,0 +1,291 @@
+#version 460
+#extension GL_ARB_gpu_shader_int64 : require
+#extension GL_EXT_shader_atomic_int64 : require
+
+// =============================================================================
+// sphere_classify.compute - Sphere Classification with Depth Priority
+// =============================================================================
+//
+// This shader classifies spheres with depth-aware tile assignment.
+// When a tile overflows, closer entities replace farther ones.
+//
+// For each sphere:
+//   1. Frustum culling
+//   2. BBox extraction
+//   3. Classification by area:
+//      - SMALL: Store index in small sphere list
+//      - LARGE: Store in tiles with depth priority
+//
+// Dispatch: (sphereCount / 256, 1, 1)
+// =============================================================================
+
+layout(local_size_x = 256) in;
+
+// -----------------------------------------------------------------------------
+// Constants
+// -----------------------------------------------------------------------------
+
+#define TILE_SIZE 16
+#define TILE_SIZE_SHIFT 4
+#define MAX_ENTITIES_PER_TILE 256
+
+// -----------------------------------------------------------------------------
+// Tile Bindings
+// -----------------------------------------------------------------------------
+
+layout(std430, binding = 2) buffer TileSphereCounts {
+    uint tileSphereCounts[];
+};
+
+layout(std430, binding = 4) buffer TileSphereIndices {
+    uint tileSphereIndices[];  // [tileIndex * MAX_ENTITIES_PER_TILE + localIndex]
+};
+
+// Depth data for priority (uint = floatBitsToUint for atomicCompSwap)
+layout(std430, binding = 14) buffer TileSphereDepthsUint {
+    uint tileSphereDepthsUint[];  // [tileIndex * MAX_ENTITIES_PER_TILE + slot]
+};
+
+// Max depth cache per tile: uint64 = (depthBits << 32) | slot, updated with atomicMax
+layout(std430, binding = 16) buffer TileSphereMaxCache {
+    uint64_t tileSphereMaxCache[];  // [tileIndex]
+};
+
+// -----------------------------------------------------------------------------
+// Small Sphere Output
+// -----------------------------------------------------------------------------
+
+layout(std430, binding = 10) buffer SmallSphereCounter {
+    uint smallSphereCount;
+};
+
+layout(std430, binding = 12) buffer SmallSphereIndices {
+    uint smallSphereIndices[];  // List of sphere indices that are "small"
+};
+
+// -----------------------------------------------------------------------------
+// Input Bindings
+// -----------------------------------------------------------------------------
+
+layout(std430, binding = 6) buffer SphereBuffer {
+    vec4 spheres[];  // xyz = position, w = radius
+};
+
+// -----------------------------------------------------------------------------
+// Uniforms
+// -----------------------------------------------------------------------------
+
+uniform mat4 view;
+uniform mat4 proj;
+
+uniform vec4 frustumTopFace;
+uniform vec4 frustumBottomFace;
+uniform vec4 frustumRightFace;
+uniform vec4 frustumLeftFace;
+uniform vec4 frustumFarFace;
+uniform vec4 frustumNearFace;
+
+uniform ivec2 screenResolution;
+
+uniform int sphereCount;
+uniform int smallEntityThreshold;
+uniform int tilesX;
+uniform int tilesY;
+uniform vec3 cameraPos;
+
+// -----------------------------------------------------------------------------
+// Frustum Culling
+// -----------------------------------------------------------------------------
+
+bool isOnOrForwardOfPlane(vec4 plane, vec4 spherePosR) {
+    return dot(plane.xyz, spherePosR.xyz) - plane.w >= -spherePosR.w;
+}
+
+bool isSphereInFrustum(vec4 spherePosR) {
+    return isOnOrForwardOfPlane(frustumLeftFace, spherePosR) &&
+           isOnOrForwardOfPlane(frustumRightFace, spherePosR) &&
+           isOnOrForwardOfPlane(frustumFarFace, spherePosR) &&
+           isOnOrForwardOfPlane(frustumNearFace, spherePosR) &&
+           isOnOrForwardOfPlane(frustumTopFace, spherePosR) &&
+           isOnOrForwardOfPlane(frustumBottomFace, spherePosR);
+}
+
+// -----------------------------------------------------------------------------
+// BBox Computation
+// -----------------------------------------------------------------------------
+
+void computeSphereBBox(vec4 spherePosR, out ivec2 screenMin, out ivec2 screenMax) {
+    // Transform to camera space
+    vec3 cameraSpaceSphere = vec3(view * vec4(spherePosR.xyz, 1.0));
+    vec3 normCamSpaceSphere = normalize(cameraSpaceSphere);
+    vec3 camImposPos = cameraSpaceSphere - normCamSpaceSphere * spherePosR.w;
+    
+    // Compute billboard scale
+    float dist = length(cameraSpaceSphere) + 1e-6;
+    float sinAngle = spherePosR.w / dist;
+    float tanAngle = tan(asin(min(sinAngle, 0.999)));
+    float quadScale = tanAngle * length(camImposPos);
+    
+    // Compute billboard vectors
+    vec3 impU = normalize(cross(normCamSpaceSphere, vec3(0.0, 1.0, 0.0)));
+    if (length(impU) < 0.001) impU = vec3(1.0, 0.0, 0.0);
+    vec3 impV = cross(impU, normCamSpaceSphere) * quadScale;
+    impU *= quadScale;
+    
+    // Compute and project corners
+    vec3 corners[4];
+    corners[0] = camImposPos + impU + impV;
+    corners[1] = camImposPos - impU + impV;
+    corners[2] = camImposPos + impU - impV;
+    corners[3] = camImposPos - impU - impV;
+    
+    vec2 minC = vec2(1e6);
+    vec2 maxC = vec2(-1e6);
+    
+    for (int i = 0; i < 4; i++) {
+        vec4 clip = proj * vec4(corners[i], 1.0);
+        if (clip.w > 0.001) {
+            vec2 ndc = clip.xy / clip.w;
+            minC = min(minC, ndc);
+            maxC = max(maxC, ndc);
+        }
+    }
+    
+    // Convert to screen coordinates
+    screenMin.x = int(floor((minC.x * 0.5 + 0.5) * float(screenResolution.x)));
+    screenMin.y = int(floor((minC.y * 0.5 + 0.5) * float(screenResolution.y)));
+    screenMax.x = int(ceil((maxC.x * 0.5 + 0.5) * float(screenResolution.x)));
+    screenMax.y = int(ceil((maxC.y * 0.5 + 0.5) * float(screenResolution.y)));
+    
+    // Clamp to screen
+    screenMin = max(screenMin, ivec2(0));
+    screenMax = min(screenMax, screenResolution);
+}
+
+// -----------------------------------------------------------------------------
+// Tile Assignment for Large Spheres (with depth priority)
+// -----------------------------------------------------------------------------
+
+void assignToTileWithPriority(uint sphereIndex, int tileIndex, float depth) {
+    uint depthBits = floatBitsToUint(depth);
+    
+    // Try to get a slot
+    uint slot = atomicAdd(tileSphereCounts[tileIndex], 1u);
+    
+    if (slot < MAX_ENTITIES_PER_TILE) {
+        // Normal insertion - there's space
+        uint idx = tileIndex * MAX_ENTITIES_PER_TILE + slot;
+        tileSphereIndices[idx] = sphereIndex;
+        tileSphereDepthsUint[idx] = depthBits;
+        
+        // Update max cache atomically: packed = (depthBits << 32) | slot
+        // Larger depth = farther; atomicMax ensures farthest wins
+        uint64_t packed = (uint64_t(depthBits) << 32) | uint64_t(slot);
+        atomicMax(tileSphereMaxCache[tileIndex], packed);
+    } else {
+        // Overflow - revert the count increment
+        atomicAdd(tileSphereCounts[tileIndex], -1u);
+        
+        // Read cache (single 64-bit load is atomic)
+        uint64_t cacheVal = tileSphereMaxCache[tileIndex];
+        uint maxDepthBits = uint(cacheVal >> 32);
+        uint maxSlot = uint(cacheVal & 0xFFFFFFFFu);
+        
+        // Only replace if we're closer (smaller depth) and slot is valid
+        if (depthBits < maxDepthBits && maxSlot < MAX_ENTITIES_PER_TILE) {
+            uint idx = tileIndex * MAX_ENTITIES_PER_TILE + maxSlot;
+            
+            // Atomically claim the slot: only one thread wins
+            uint oldDepthBits = atomicCompSwap(tileSphereDepthsUint[idx], maxDepthBits, depthBits);
+            
+            if (oldDepthBits == maxDepthBits) {
+                // We won - write the index
+                tileSphereIndices[idx] = sphereIndex;
+                
+                // Update cache with atomicMax (our packed value)
+                uint64_t ourPacked = (uint64_t(depthBits) << 32) | uint64_t(maxSlot);
+                atomicMax(tileSphereMaxCache[tileIndex], ourPacked);
+            }
+        }
+    }
+}
+
+void assignToTiles(uint sphereIndex, ivec2 screenMin, ivec2 screenMax, float depth) {
+    // Compute tile range
+    int tileMinX = screenMin.x >> TILE_SIZE_SHIFT;
+    int tileMinY = screenMin.y >> TILE_SIZE_SHIFT;
+    int tileMaxX = max(0, screenMax.x - 1) >> TILE_SIZE_SHIFT;
+    int tileMaxY = max(0, screenMax.y - 1) >> TILE_SIZE_SHIFT;
+    
+    // Clamp to valid tile range
+    tileMinX = clamp(tileMinX, 0, tilesX - 1);
+    tileMinY = clamp(tileMinY, 0, tilesY - 1);
+    tileMaxX = clamp(tileMaxX, 0, tilesX - 1);
+    tileMaxY = clamp(tileMaxY, 0, tilesY - 1);
+    
+    // Assign sphere to each overlapping tile with depth priority
+    for (int ty = tileMinY; ty <= tileMaxY; ty++) {
+        for (int tx = tileMinX; tx <= tileMaxX; tx++) {
+            int tileIndex = ty * tilesX + tx;
+            assignToTileWithPriority(sphereIndex, tileIndex, depth);
+        }
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Main
+// -----------------------------------------------------------------------------
+
+void main() {
+    uint sphereIndex = gl_GlobalInvocationID.x;
+    
+    if (sphereIndex >= sphereCount) {
+        return;
+    }
+    
+    vec4 spherePosR = spheres[sphereIndex];
+    
+    // =========================================================================
+    // STAGE 1: Frustum Culling
+    // =========================================================================
+    
+    if (!isSphereInFrustum(spherePosR)) {
+        return;
+    }
+    
+    // =========================================================================
+    // STAGE 2: BBox Extraction
+    // =========================================================================
+    
+    ivec2 screenMin, screenMax;
+    computeSphereBBox(spherePosR, screenMin, screenMax);
+    
+    // Compute bbox area
+    int width = screenMax.x - screenMin.x;
+    int height = screenMax.y - screenMin.y;
+    int area = width * height;
+    
+    // Skip tiny spheres
+    if (area < 1) {
+        return;
+    }
+    
+    // =========================================================================
+    // STAGE 3: Compute Depth (distance from camera to sphere center)
+    // =========================================================================
+    
+    float depth = distance(cameraPos, spherePosR.xyz);
+    
+    // =========================================================================
+    // STAGE 4: Classification
+    // =========================================================================
+    
+    if (area <= smallEntityThreshold) {
+        // SMALL: Add to small sphere list for direct rasterization later
+        uint slot = atomicAdd(smallSphereCount, 1u);
+        smallSphereIndices[slot] = sphereIndex;
+    } else {
+        // LARGE: Assign to overlapping tiles with depth priority
+        assignToTiles(sphereIndex, screenMin, screenMax, depth);
+    }
+}

--- a/assets/shaders/hybrid_glsl/tiled_cylinder_raster_old.compute
+++ b/assets/shaders/hybrid_glsl/tiled_cylinder_raster_old.compute
@@ -1,0 +1,344 @@
+#version 460
+
+// =============================================================================
+// tiled_cylinder_raster.compute - Tiled Rasterization for Large Cylinders
+// =============================================================================
+//
+// This shader processes large cylinders using a tiled approach:
+// - Each work group = one tile (variable size: 8, 16, 32, or 64)
+// - Work group size is fixed at 16x16 (256 threads)
+// - For small tiles: some threads idle
+// - For large tiles: each thread processes multiple pixels
+//
+// Dispatch: (tilesX, tilesY, 1)
+// =============================================================================
+
+layout(local_size_x = 16, local_size_y = 16) in;
+
+// -----------------------------------------------------------------------------
+// Constants
+// -----------------------------------------------------------------------------
+
+#define TILE_SIZE 16
+#define BATCH_SIZE 64
+
+// -----------------------------------------------------------------------------
+// Output Bindings
+// -----------------------------------------------------------------------------
+
+layout(rgba8, binding = 0) uniform image2D outputImage;
+
+layout(std430, binding = 1) buffer DepthBuffer {
+    uint depthBuffer[];
+};
+
+// -----------------------------------------------------------------------------
+// Tile Data Bindings
+// -----------------------------------------------------------------------------
+
+layout(std430, binding = 3) buffer TileCylinderCounts {
+    uint tileCylinderCounts[];
+};
+
+layout(std430, binding = 5) buffer TileCylinderIndices {
+    uint tileCylinderIndices[];
+};
+
+// -----------------------------------------------------------------------------
+// Entity Data Bindings
+// -----------------------------------------------------------------------------
+
+struct Cylinder {
+    vec4 pa_r;
+    vec4 pb_r;
+};
+
+layout(std430, binding = 7) buffer CylinderBuffer {
+    Cylinder cylinders[];
+};
+
+// -----------------------------------------------------------------------------
+// Uniforms
+// -----------------------------------------------------------------------------
+
+uniform mat4 view;
+uniform mat4 proj;
+
+uniform vec3 front;
+uniform vec3 up;
+uniform vec3 right;
+uniform vec3 cameraPos;
+
+uniform ivec2 screenResolution;
+uniform float fov;
+
+uniform int tilesX;
+uniform int tilesY;
+uniform int maxEntitiesPerTile;
+
+// Screen ray casting uniforms (computed on CPU)
+uniform vec3 rayStart;  // Bottom-left corner ray direction (world space)
+uniform vec3 rayDx;     // Delta per pixel in X
+uniform vec3 rayDy;     // Delta per pixel in Y
+
+// -----------------------------------------------------------------------------
+// Shared Memory
+// -----------------------------------------------------------------------------
+
+shared vec4 shCylPa[BATCH_SIZE];
+shared vec4 shCylPb[BATCH_SIZE];
+// Store 4 corners of the rotated quad per cylinder (in screen space)
+shared vec2 shCylQuad[BATCH_SIZE * 4];  // [i*4+0..i*4+3] = 4 corners of cylinder i
+
+// -----------------------------------------------------------------------------
+// Constants
+// -----------------------------------------------------------------------------
+
+const vec3 lightColor = vec3(0.01, 1.0, 0.05);
+const float diffuseI = 0.9;
+
+// -----------------------------------------------------------------------------
+// Rotated Quad Computation (same as in cylinder_classify.compute)
+// -----------------------------------------------------------------------------
+
+void computeCylinderQuad(vec3 pa, vec3 pb, float cylRadius, out vec2 corners[4]) {
+    // Transform to camera space
+    vec3 camSpaceCylA = vec3(view * vec4(pa, 1.0));
+    vec3 camSpaceCylB = vec3(view * vec4(pb, 1.0));
+    
+    // Order by depth (A closer, B farther)
+    vec3 camImpPosA, camImpPosB;
+    if (camSpaceCylA.z < camSpaceCylB.z) {
+        camImpPosA = camSpaceCylB;
+        camImpPosB = camSpaceCylA;
+    } else {
+        camImpPosA = camSpaceCylA;
+        camImpPosB = camSpaceCylB;
+    }
+    
+    // Cylinder axis
+    vec3 z = normalize(camImpPosB - camImpPosA);
+    vec3 center = normalize((camImpPosA + camImpPosB) * 0.5);
+    
+    // Find orthonormal axes
+    vec3 x = normalize(cross(center, z));
+    vec3 y = normalize(cross(x, z));
+    
+    // Compute impostor construction vectors
+    float dV0 = length(camImpPosA);
+    float dV1 = length(camImpPosB);
+    
+    float sinAngle = cylRadius / dV0;
+    float angle = asin(min(sinAngle, 0.999));
+    vec3 y1 = y * cylRadius;
+    vec3 x2 = x * cylRadius * cos(angle);
+    vec3 y2 = y1 * sinAngle;
+    angle = asin(min(cylRadius / dV1, 0.999));
+    vec3 x3 = x * (dV1 - cylRadius) * tan(angle);
+    
+    // Compute impostor vertices
+    vec3 v1 = camImpPosA - x2 + y2;
+    vec3 v2 = camImpPosA + x2 + y2;
+    vec3 v3 = camImpPosB - x3 + y1;
+    vec3 v4 = camImpPosB + x3 + y1;
+    
+    // Project to screen
+    vec4 v1Proj = proj * vec4(v1, 1.0);
+    vec4 v2Proj = proj * vec4(v2, 1.0);
+    vec4 v3Proj = proj * vec4(v3, 1.0);
+    vec4 v4Proj = proj * vec4(v4, 1.0);
+    
+    vec2 ndc1 = v1Proj.xy / v1Proj.w;
+    vec2 ndc2 = v2Proj.xy / v2Proj.w;
+    vec2 ndc3 = v3Proj.xy / v3Proj.w;
+    vec2 ndc4 = v4Proj.xy / v4Proj.w;
+    
+    // Convert to screen coordinates
+    corners[0] = (ndc1 * 0.5 + 0.5) * vec2(screenResolution);
+    corners[1] = (ndc2 * 0.5 + 0.5) * vec2(screenResolution);
+    corners[2] = (ndc4 * 0.5 + 0.5) * vec2(screenResolution);  // Note order: v4 before v3
+    corners[3] = (ndc3 * 0.5 + 0.5) * vec2(screenResolution);
+    
+    // Clamp to screen
+    for (int i = 0; i < 4; i++) {
+        corners[i] = clamp(corners[i], vec2(0.0), vec2(screenResolution));
+    }
+}
+
+// Cross product of 2D vectors
+float cross2D(vec2 a, vec2 b) {
+    return a.x * b.y - a.y * b.x;
+}
+
+// Check if point is inside convex quadrilateral
+bool pointInQuad(vec2 p, vec2 q0, vec2 q1, vec2 q2, vec2 q3) {
+    float c0 = cross2D(q1 - q0, p - q0);
+    float c1 = cross2D(q2 - q1, p - q1);
+    float c2 = cross2D(q3 - q2, p - q2);
+    float c3 = cross2D(q0 - q3, p - q3);
+    
+    return (c0 >= 0 && c1 >= 0 && c2 >= 0 && c3 >= 0) ||
+           (c0 <= 0 && c1 <= 0 && c2 <= 0 && c3 <= 0);
+}
+
+// -----------------------------------------------------------------------------
+// Ray-Cylinder Intersection
+// -----------------------------------------------------------------------------
+
+vec4 iCylinder(vec3 ro, vec3 rd, vec3 pa, vec3 pb, float ra) 
+{
+    vec3  ba = pb - pa;
+    vec3  oc = ro - pa;
+
+    float baba = dot(ba,ba);
+    float bard = dot(ba,rd);
+    float baoc = dot(ba,oc);
+    
+    float k2 = baba - bard*bard;
+    float k1 = baba*dot(oc,rd) - baoc*bard;
+    float k0 = baba*dot(oc,oc) - baoc*baoc - ra*ra*baba;
+    
+    
+    float h = k1*k1 - k2*k0;
+    if( h<0.0f ) return vec4(-1.0f);
+    h = sqrt(h);
+    float t = (-k1-h)/k2;
+
+    // body
+    float y = baoc + t*bard;
+    if( y>0.0f && y<baba ) return vec4( t, oc+t*rd - ba*y/baba );
+    
+    // caps
+    // t = ( ((y<0.0f) ? 0.0f : baba) - baoc)/bard;
+    // if( abs(k1+k2*t)<h ) return vec4( t, ba*sign(y)/sqrt(baba) );
+
+    return vec4(-1.0f);
+}
+
+// -----------------------------------------------------------------------------
+// Ray Direction
+// -----------------------------------------------------------------------------
+
+vec3 computeRd(int px, int py, float fovTan, float halfFovTan) {
+    vec2 p = (-vec2(screenResolution) + 2.0 * vec2(px, py)) / vec2(screenResolution);
+    return normalize(p.x * right * halfFovTan + p.y * up * fovTan + front);
+}
+
+// -----------------------------------------------------------------------------
+// Main
+// -----------------------------------------------------------------------------
+
+void main() {
+    int tileX = int(gl_WorkGroupID.x);
+    int tileY = int(gl_WorkGroupID.y);
+    int tileIndex = tileY * tilesX + tileX;
+    
+    int localX = int(gl_LocalInvocationID.x);
+    int localY = int(gl_LocalInvocationID.y);
+    int localIndex = localY * TILE_SIZE + localX;
+
+    int pixelX = tileX * TILE_SIZE + localX;
+    int pixelY = tileY * TILE_SIZE + localY;
+
+    if (!(pixelX < screenResolution.x && pixelY < screenResolution.y))
+        return;
+    
+    
+    // Load tile cylinder count
+    uint cylinderCount = min(tileCylinderCounts[tileIndex], uint(maxEntitiesPerTile));
+    
+    if (cylinderCount == 0) {
+        return;
+    }
+    
+    // Precompute ray parameters
+    float aspectRatio = float(screenResolution.x) / float(screenResolution.y);
+    float fovRad = radians(fov);
+    float fovTan = tan(fovRad * 0.5);
+    float halfFovTan = fovTan * aspectRatio;
+
+    vec3 rd = computeRd(pixelX, pixelY, fovTan, halfFovTan);
+
+    float minDepth = 1e10;
+    vec3 finalColor = vec3(0.0);
+    bool hasHit = false;
+    
+    // Process cylinders in batches
+    uint numBatches = (cylinderCount + BATCH_SIZE - 1) / BATCH_SIZE;
+    
+    for (uint batch = 0; batch < numBatches; batch++) {
+        uint batchStart = batch * BATCH_SIZE;
+        
+        // Cooperative loading into shared memory
+        if (localIndex < BATCH_SIZE) {
+            uint entityIdx = batchStart + localIndex;
+            if (entityIdx < cylinderCount) {
+                uint cylIndex = tileCylinderIndices[tileIndex * maxEntitiesPerTile + entityIdx];
+                Cylinder cyl = cylinders[cylIndex];
+                shCylPa[localIndex] = cyl.pa_r;
+                shCylPb[localIndex] = cyl.pb_r;
+                
+                // Compute rotated quad corners
+                vec2 corners[4];
+                computeCylinderQuad(cyl.pa_r.xyz, cyl.pb_r.xyz, cyl.pa_r.w, corners);
+                
+                // Store in shared memory
+                shCylQuad[localIndex * 4 + 0] = corners[0];
+                shCylQuad[localIndex * 4 + 1] = corners[1];
+                shCylQuad[localIndex * 4 + 2] = corners[2];
+                shCylQuad[localIndex * 4 + 3] = corners[3];
+            }
+        }
+        barrier();
+        
+        // Process this batch
+        uint batchCount = min(BATCH_SIZE, cylinderCount - batchStart);
+        
+        
+        // Each thread processes multiple pixels if needed
+        for (int i = 0; i < batchCount; i++) {
+            vec4 pa_r = shCylPa[i];
+            vec4 pb_r = shCylPb[i];
+
+            vec2 q0 = shCylQuad[i * 4 + 0];
+            vec2 q1 = shCylQuad[i * 4 + 1];
+            vec2 q2 = shCylQuad[i * 4 + 2];
+            vec2 q3 = shCylQuad[i * 4 + 3];
+                
+            // Check if pixel is inside the rotated quad
+            vec2 pixelCenter = vec2(float(pixelX) + 0.5, float(pixelY) + 0.5);
+            if (!pointInQuad(pixelCenter, q0, q1, q2, q3)) {
+                continue;
+            }
+            
+            vec4 tnor = iCylinder(cameraPos, rd, pa_r.xyz, pb_r.xyz, pa_r.w);
+            
+            if (tnor.x > 0.0) {
+                float t = tnor.x;
+                vec3 rayColStart = rayStart + float(pixelY) * rayDy;
+                vec3 hit = (rayColStart + float(pixelX) * rayDx) * t;
+                float depth = (hit.z * proj[2].z + proj[3].z) / -hit.z;
+                
+                if (depth < minDepth) {
+                    minDepth = depth;
+                    hasHit = true;
+                    
+                    vec3 normal = normalize(tnor.yzw);
+                    float lambertCos = dot(normal, -normalize(t * rd));
+                    finalColor = lambertCos * lightColor * diffuseI;
+                }
+            }
+        }
+        barrier();
+    }
+     // Write result
+    if (hasHit) {
+        int pixelIndex = pixelY * screenResolution.x + pixelX;
+        uint depthU = floatBitsToUint(minDepth);
+                
+        if (depthBuffer[pixelIndex] > depthU) {
+            imageStore(outputImage, ivec2(pixelX, pixelY), vec4(finalColor, 1.0));
+            depthBuffer[pixelIndex] = depthU;
+        }
+    }
+}

--- a/assets/shaders/hybrid_glsl/tiled_sphere_raster_old.compute
+++ b/assets/shaders/hybrid_glsl/tiled_sphere_raster_old.compute
@@ -1,0 +1,263 @@
+#version 460
+
+// =============================================================================
+// tiled_sphere_raster.compute - Tiled Rasterization for Large Spheres
+// =============================================================================
+//
+// This shader processes large spheres using a tiled approach:
+// - Each work group = one tile (16x16 pixels)
+// - Each thread = one pixel
+// - Spheres are loaded by index and bbox is RECOMPUTED in shared memory
+//
+// Dispatch: (tilesX, tilesY, 1)
+// =============================================================================
+
+layout(local_size_x = 16, local_size_y = 16) in;
+
+// -----------------------------------------------------------------------------
+// Constants
+// -----------------------------------------------------------------------------
+
+#define TILE_SIZE 16
+#define MAX_ENTITIES_PER_TILE 256
+#define BATCH_SIZE 64
+
+// -----------------------------------------------------------------------------
+// Output Bindings
+// -----------------------------------------------------------------------------
+
+layout(rgba8, binding = 0) uniform image2D outputImage;
+
+layout(std430, binding = 1) buffer DepthBuffer {
+    uint depthBuffer[];
+};
+
+// -----------------------------------------------------------------------------
+// Tile Data Bindings
+// -----------------------------------------------------------------------------
+
+layout(std430, binding = 2) buffer TileSphereCounts {
+    uint tileSphereCounts[];
+};
+
+layout(std430, binding = 4) buffer TileSphereIndices {
+    uint tileSphereIndices[];
+};
+
+// -----------------------------------------------------------------------------
+// Entity Data Bindings
+// -----------------------------------------------------------------------------
+
+layout(std430, binding = 6) buffer SphereBuffer {
+    vec4 spheres[];
+};
+
+// -----------------------------------------------------------------------------
+// Uniforms
+// -----------------------------------------------------------------------------
+
+uniform mat4 view;
+uniform mat4 proj;
+
+uniform vec3 front;
+uniform vec3 up;
+uniform vec3 right;
+uniform vec3 cameraPos;
+
+uniform ivec2 screenResolution;
+uniform float fov;
+
+uniform int tilesX;
+uniform int tilesY;
+
+// Screen ray casting uniforms (computed on CPU)
+uniform vec3 rayStart;  // Bottom-left corner ray direction (world space)
+uniform vec3 rayDx;     // Delta per pixel in X
+uniform vec3 rayDy;     // Delta per pixel in Y
+
+// -----------------------------------------------------------------------------
+// Shared Memory
+// -----------------------------------------------------------------------------
+
+shared vec4 shSpherePosR[BATCH_SIZE];
+shared ivec4 shSphereBBox[BATCH_SIZE];
+
+// -----------------------------------------------------------------------------
+// Constants
+// -----------------------------------------------------------------------------
+
+const vec3 lightColor = vec3(0.01, 1.0, 0.05);
+const float diffuseI = 0.9;
+
+// -----------------------------------------------------------------------------
+// BBox Computation
+// -----------------------------------------------------------------------------
+
+ivec4 computeSphereBBox(vec4 spherePosR) {
+    vec3 cameraSpaceSphere = vec3(view * vec4(spherePosR.xyz, 1.0));
+    vec3 normCamSpaceSphere = normalize(cameraSpaceSphere);
+    vec3 camImposPos = cameraSpaceSphere - normCamSpaceSphere * spherePosR.w;
+    
+    float dist = length(cameraSpaceSphere) + 1e-6;
+    float sinAngle = spherePosR.w / dist;
+    float tanAngle = tan(asin(min(sinAngle, 0.999)));
+    float quadScale = tanAngle * length(camImposPos);
+    
+    vec3 impU = normalize(cross(normCamSpaceSphere, vec3(0.0, 1.0, 0.0)));
+    if (length(impU) < 0.001) impU = vec3(1.0, 0.0, 0.0);
+    vec3 impV = cross(impU, normCamSpaceSphere) * quadScale;
+    impU *= quadScale;
+    
+    vec3 corners[4];
+    corners[0] = camImposPos + impU + impV;
+    corners[1] = camImposPos - impU + impV;
+    corners[2] = camImposPos + impU - impV;
+    corners[3] = camImposPos - impU - impV;
+    
+    vec2 minC = vec2(1e6);
+    vec2 maxC = vec2(-1e6);
+    
+    for (int i = 0; i < 4; i++) {
+        vec4 clip = proj * vec4(corners[i], 1.0);
+        if (clip.w > 0.001) {
+            vec2 ndc = clip.xy / clip.w;
+            minC = min(minC, ndc);
+            maxC = max(maxC, ndc);
+        }
+    }
+    
+    ivec4 bbox;
+    bbox.x = int(floor((minC.x * 0.5 + 0.5) * float(screenResolution.x)));
+    bbox.y = int(floor((minC.y * 0.5 + 0.5) * float(screenResolution.y)));
+    bbox.z = int(ceil((maxC.x * 0.5 + 0.5) * float(screenResolution.x)));
+    bbox.w = int(ceil((maxC.y * 0.5 + 0.5) * float(screenResolution.y)));
+    
+    bbox.xy = max(bbox.xy, ivec2(0));
+    bbox.zw = min(bbox.zw, screenResolution);
+    
+    return bbox;
+}
+
+// -----------------------------------------------------------------------------
+// Ray-Sphere Intersection
+// -----------------------------------------------------------------------------
+
+float iSphere(vec3 ro, vec3 rd, vec3 sph, float radius) {
+    vec3 oc = ro - sph;
+    float b = dot(oc, rd);
+    float c = dot(oc, oc) - radius * radius;
+    float h = b * b - c;
+    if (h < 0.0) return -1.0;
+    return -b - sqrt(h);
+}
+
+// -----------------------------------------------------------------------------
+// Ray Direction
+// -----------------------------------------------------------------------------
+
+vec3 computeRd(int px, int py, float fovTan, float halfFovTan) {
+    vec2 p = (-vec2(screenResolution) + 2.0 * vec2(px, py)) / vec2(screenResolution);
+    return normalize(p.x * right * halfFovTan + p.y * up * fovTan + front);
+}
+
+// -----------------------------------------------------------------------------
+// Main
+// -----------------------------------------------------------------------------
+
+void main() {
+    // Compute tile and pixel coordinates
+    int tileX = int(gl_WorkGroupID.x);
+    int tileY = int(gl_WorkGroupID.y);
+    int tileIndex = tileY * tilesX + tileX;
+    
+    int localX = int(gl_LocalInvocationID.x);
+    int localY = int(gl_LocalInvocationID.y);
+    int localIndex = localY * TILE_SIZE + localX;
+    
+    int pixelX = tileX * TILE_SIZE + localX;
+    int pixelY = tileY * TILE_SIZE + localY;
+    
+    if (!(pixelX < screenResolution.x && pixelY < screenResolution.y))
+        return;
+    
+    // Load tile sphere count
+    uint sphereCount = min(tileSphereCounts[tileIndex], uint(MAX_ENTITIES_PER_TILE));
+    
+    if (sphereCount == 0) {
+        return;
+    }
+    
+    // Precompute ray parameters
+    float aspectRatio = float(screenResolution.x) / float(screenResolution.y);
+    float fovRad = radians(fov);
+    float fovTan = tan(fovRad * 0.5);
+    float halfFovTan = fovTan * aspectRatio;
+    
+    vec3 rd = computeRd(pixelX, pixelY, fovTan, halfFovTan);
+
+    float minDepth = 1e10;
+    vec3 finalColor = vec3(0.0);
+    bool hasHit = false;
+    
+    // Process spheres in batches
+    uint numBatches = (sphereCount + BATCH_SIZE - 1) / BATCH_SIZE;
+    
+    for (uint batch = 0; batch < numBatches; batch++) {
+        uint batchStart = batch * BATCH_SIZE;
+        
+        // Cooperative loading into shared memory
+        if (localIndex < BATCH_SIZE) {
+            uint entityIdx = batchStart + localIndex;
+            if (entityIdx < sphereCount) {
+                uint sphereIndex = tileSphereIndices[tileIndex * MAX_ENTITIES_PER_TILE + entityIdx];
+                vec4 posR = spheres[sphereIndex];
+                shSpherePosR[localIndex] = posR;
+                shSphereBBox[localIndex] = computeSphereBBox(posR);
+            }
+        }
+        barrier();
+        
+        // Process this batch
+        uint batchCount = min(BATCH_SIZE, sphereCount - batchStart);
+        
+        for (uint i = 0; i < batchCount; i++) {
+            vec4 posR = shSpherePosR[i];
+            ivec4 bbox = shSphereBBox[i];
+            
+            // Check if pixel is within bbox
+            if (pixelX < bbox.x || pixelX >= bbox.z ||
+                pixelY < bbox.y || pixelY >= bbox.w) {
+                continue;
+            }
+            
+            float t = iSphere(cameraPos, rd, posR.xyz, posR.w);
+            
+            if (t > 0.0) {
+                vec3 rayColStart = rayStart + float(pixelY) * rayDy;
+                vec3 hit = (rayColStart + float(pixelX) * rayDx) * t;
+                float depth = (hit.z * proj[2].z + proj[3].z) / -hit.z;
+                
+                if (depth < minDepth) {
+                    minDepth = depth;
+                    hasHit = true;
+                    
+                    vec3 normal = normalize(cameraPos + rd * t - posR.xyz);
+                    float lambert = max(0.0, dot(normal, -normalize(rd)));
+                    finalColor = lightColor * lambert * diffuseI;
+                }
+            }
+        }
+        barrier();
+    }
+    
+    // Write result
+    if (hasHit) {
+        int pixelIndex = pixelY * screenResolution.x + pixelX;
+        uint depthU = floatBitsToUint(minDepth);
+                
+        if (depthBuffer[pixelIndex] > depthU) {
+            imageStore(outputImage, ivec2(pixelX, pixelY), vec4(finalColor, 1.0));
+            depthBuffer[pixelIndex] = depthU;
+        }
+    }
+}

--- a/executables/CMakeLists.txt
+++ b/executables/CMakeLists.txt
@@ -32,6 +32,7 @@ endif()
 if(BUILD_CUDA_VERSION)
     add_subdirectory(cuda)
     add_subdirectory(cuda_hybrid)
+    add_subdirectory(cuda_hybrid_binning)
 endif()
 
 # Hybrid GLSL version - uses same dependencies as FST_PARALLEL

--- a/executables/cuda_hybrid_binning/CMakeLists.txt
+++ b/executables/cuda_hybrid_binning/CMakeLists.txt
@@ -42,11 +42,11 @@ target_include_directories(cuda_hybrid_binning_pipeline PRIVATE
 
 configure_cuda_target(cuda_hybrid_binning_pipeline)
 
-target_compile_definitions(cuda_hybrid_binning_pipeline PRIVATE
-    GLM_FORCE_CUDA
-    GLM_ENABLE_EXPERIMENTAL
-    GLM_FORCE_INLINE
-)
+# target_compile_definitions(cuda_hybrid_binning_pipeline PRIVATE
+#     GLM_FORCE_CUDA
+#     GLM_ENABLE_EXPERIMENTAL
+#     GLM_FORCE_INLINE
+# )
 
 if(CMAKE_BUILD_TYPE STREQUAL "Release")
     target_compile_options(cuda_hybrid_binning_pipeline PRIVATE

--- a/executables/cuda_hybrid_binning/CMakeLists.txt
+++ b/executables/cuda_hybrid_binning/CMakeLists.txt
@@ -1,0 +1,67 @@
+# ==============================================================================
+# cuda_hybrid_binning - Hybrid CUDA pipeline with binning-by-sort (CUB)
+# ==============================================================================
+# No linked lists; uses CUB DeviceRadixSort + DeviceRunLengthEncode for tile offsets.
+# ==============================================================================
+
+message(STATUS "Configurando hybrid binning CUDA...")
+
+set(CUDA_HYBRID_BINNING_OUTPUT_DIR "${CMAKE_BINARY_DIR}/bin/cuda_hybrid_binning")
+set(CUDA_HYBRID_BINNING_KERNELS_DIR "${CMAKE_SOURCE_DIR}/kernels/hybrid_binning")
+
+set(CUDA_HYBRID_BINNING_KERNELS
+    "${CUDA_HYBRID_BINNING_KERNELS_DIR}/frustum_bbox_classify.cu"
+    "${CUDA_HYBRID_BINNING_KERNELS_DIR}/generate_pairs.cu"
+    "${CUDA_HYBRID_BINNING_KERNELS_DIR}/sort_and_rle.cu"
+    "${CUDA_HYBRID_BINNING_KERNELS_DIR}/screen_clear.cu"
+    "${CUDA_HYBRID_BINNING_KERNELS_DIR}/small_entity_raster.cu"
+    "${CUDA_HYBRID_BINNING_KERNELS_DIR}/tiled_raster_binning.cu"
+    "${CUDA_HYBRID_BINNING_KERNELS_DIR}/sphere_pipeline_binning.cu"
+    "${CUDA_HYBRID_BINNING_KERNELS_DIR}/cylinder_pipeline_binning.cu"
+)
+
+add_executable(cuda_hybrid_binning_pipeline
+    ${CMAKE_SOURCE_DIR}/executables/cuda_hybrid_binning/hybrid_binning_pipeline.cpp
+    ${CUDA_HYBRID_BINNING_KERNELS}
+)
+
+set_source_files_properties(${CUDA_HYBRID_BINNING_KERNELS} PROPERTIES LANGUAGE CUDA)
+
+target_link_libraries(cuda_hybrid_binning_pipeline PRIVATE
+    lib_core
+    lib_parallel
+    lib_cuda_interop
+)
+
+target_include_directories(cuda_hybrid_binning_pipeline PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/kernels
+    ${EXTERN_INCLUDE_DIRS}
+    ${CUDA_INCLUDE_DIRS}
+)
+
+configure_cuda_target(cuda_hybrid_binning_pipeline)
+
+target_compile_definitions(cuda_hybrid_binning_pipeline PRIVATE
+    GLM_FORCE_CUDA
+    GLM_ENABLE_EXPERIMENTAL
+    GLM_FORCE_INLINE
+)
+
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+    target_compile_options(cuda_hybrid_binning_pipeline PRIVATE
+        $<$<COMPILE_LANGUAGE:CUDA>:-O3 --use_fast_math -Xptxas=-v --maxrregcount=64>
+    )
+else()
+    target_compile_options(cuda_hybrid_binning_pipeline PRIVATE
+        $<$<COMPILE_LANGUAGE:CUDA>:-G -lineinfo>
+    )
+endif()
+
+set_target_properties(cuda_hybrid_binning_pipeline PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY "${CUDA_HYBRID_BINNING_OUTPUT_DIR}"
+    VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
+    CUDA_SEPARABLE_COMPILATION ON
+)
+
+message(STATUS "  - cuda_hybrid_binning_pipeline")

--- a/executables/cuda_hybrid_binning/hybrid_binning_pipeline.cpp
+++ b/executables/cuda_hybrid_binning/hybrid_binning_pipeline.cpp
@@ -288,6 +288,7 @@ int main(int argc, char* argv[]) {
         profiler.updateProfiler(benchmark.getCheckpointID(), visibleSpheres, drawnSpheres, visibleCylinders, drawnCylinders);
 
         Frustum frustum(camera);
+        pipeline.setSmallEntityThreshold(config.smallEntityThreshold);
         pipeline.executeFrame(d_spheres, d_cylinders, depthBuffer, outputSurface, camera, frustum, stream);
         cudaStreamSynchronize(stream);  // ensure all kernels and D2H copies finish before reading stats
 

--- a/executables/cuda_hybrid_binning/hybrid_binning_pipeline.cpp
+++ b/executables/cuda_hybrid_binning/hybrid_binning_pipeline.cpp
@@ -152,7 +152,7 @@ public:
         // cudaStreamSynchronize(stream);  /* ensure counters are 0 before classifiers run */
 
         executeSpherePipelineBinning(d_spheres, m_sphereCount, d_depthBuffer, outputImage, &m_sphereResources, stream);
-        // executeCylinderPipelineBinning(d_cylinders, m_cylinderCount, d_depthBuffer, outputImage, &m_cylinderResources, stream);
+        executeCylinderPipelineBinning(d_cylinders, m_cylinderCount, d_depthBuffer, outputImage, &m_cylinderResources, stream);
 
         nvtxRangePop();
     }

--- a/executables/cuda_hybrid_binning/hybrid_binning_pipeline.cpp
+++ b/executables/cuda_hybrid_binning/hybrid_binning_pipeline.cpp
@@ -45,6 +45,8 @@ struct HybridBinningConfig {
     int cylinderCount = 0;
     bool shown = true;
     int smallEntityThreshold = SMALL_ENTITY_THRESHOLD;
+    /** Average entities per tile for pair buffer size: buffer = avgEntitiesPerTile * totalTiles */
+    int avgEntitiesPerTile = AVG_ENTITIES_PER_TILE;
     double timerDuration = 48.0;
     int tilesX;
     int tilesY;
@@ -76,8 +78,8 @@ public:
     void initialize(int sphereCount, int cylinderCount) {
         m_sphereCount = sphereCount;
         m_cylinderCount = cylinderCount;
-        initSphereBinningResources(&m_sphereResources, sphereCount, m_config.tilesX, m_config.tilesY, m_config.totalTiles);
-        initCylinderBinningResources(&m_cylinderResources, cylinderCount, m_config.tilesX, m_config.tilesY, m_config.totalTiles);
+        initSphereBinningResources(&m_sphereResources, sphereCount, m_config.tilesX, m_config.tilesY, m_config.totalTiles, m_config.avgEntitiesPerTile);
+        initCylinderBinningResources(&m_cylinderResources, cylinderCount, m_config.tilesX, m_config.tilesY, m_config.totalTiles, m_config.avgEntitiesPerTile);
         std::cout << "Binning pipeline initialized: " << sphereCount << " spheres, " << cylinderCount << " cylinders" << std::endl;
     }
 
@@ -118,8 +120,8 @@ public:
 
         resetSphereBinningCounters(&m_sphereResources, stream);
         resetCylinderBinningCounters(&m_cylinderResources, stream);
-
         launchScreenClear(outputImage, d_depthBuffer, m_config.screenWidth, m_config.screenHeight, camera.getFar(), stream);
+        cudaStreamSynchronize(stream);  /* ensure counters are 0 before classifiers run */
 
         executeSpherePipelineBinning(d_spheres, m_sphereCount, d_depthBuffer, outputImage, &m_sphereResources, stream);
         executeCylinderPipelineBinning(d_cylinders, m_cylinderCount, d_depthBuffer, outputImage, &m_cylinderResources, stream);
@@ -222,7 +224,7 @@ int main(int argc, char* argv[]) {
                       "media/csv/cuda_hybrid_binning/process_times.csv",
                       config.sphereCount, config.cylinderCount, 0, config.timerDuration);
 
-    window.setupSceneInfoGui("Scene Info", {
+    std::unordered_map<std::string, int*> sceneData = {
         {"Screen width", &config.screenWidth},
         {"Screen height", &config.screenHeight},
         {"Sphere count", &config.sphereCount},
@@ -231,7 +233,8 @@ int main(int argc, char* argv[]) {
         {"Cylinder count", &config.cylinderCount},
         {"Visible cylinders", &visibleCylinders},
         {"Drawn cylinders", &drawnCylinders}
-    });
+    };
+    window.setupSceneInfoGui("Scene Info", sceneData);
     window.setupCameraGui("Camera Info", &camera);
     window.setupInputInfoGui("Input Info");
     window.setupBenchmarkInfoGui("Benchmark", &benchmark);

--- a/executables/cuda_hybrid_binning/hybrid_binning_pipeline.cpp
+++ b/executables/cuda_hybrid_binning/hybrid_binning_pipeline.cpp
@@ -116,15 +116,43 @@ public:
         constants.totalTiles = m_config.totalTiles;
         constants.smallEntityThreshold = m_config.smallEntityThreshold;
         constants.benchmark = 1;
+
+        // Pre-compute screen ray casting vectors (camera space)
+        {
+            float aspectRatio = (float)m_config.screenWidth / (float)m_config.screenHeight;
+            float fovRad = glm::radians(camera.getFov());
+            float fovTan = tanf(fovRad * 0.5f);
+            float halfFovTan = fovTan * aspectRatio;
+
+            glm::vec3 camFront = camera.getFront();
+            glm::vec3 camUp    = camera.getUp();
+            glm::vec3 camRight = camera.getRight();
+
+            // Corner ray directions in world space
+            glm::vec3 corner00 = glm::normalize(-halfFovTan * camRight - fovTan * camUp + camFront);
+            glm::vec3 corner10 = glm::normalize( halfFovTan * camRight - fovTan * camUp + camFront);
+            glm::vec3 corner01 = glm::normalize(-halfFovTan * camRight + fovTan * camUp + camFront);
+
+            // Transform to camera space via the 3x3 rotation part of the view matrix
+            glm::mat3 viewRot = glm::mat3(camera.getView());
+            glm::vec3 wCorner00 = viewRot * corner00;
+            glm::vec3 wCorner10 = viewRot * corner10;
+            glm::vec3 wCorner01 = viewRot * corner01;
+
+            constants.rayStart = wCorner00;
+            constants.dx = (wCorner10 - wCorner00) / (float)m_config.screenWidth;
+            constants.dy = (wCorner01 - wCorner00) / (float)m_config.screenHeight;
+        }
+
         uploadHybridConstants(constants, stream);
 
         resetSphereBinningCounters(&m_sphereResources, stream);
         resetCylinderBinningCounters(&m_cylinderResources, stream);
         launchScreenClear(outputImage, d_depthBuffer, m_config.screenWidth, m_config.screenHeight, camera.getFar(), stream);
-        cudaStreamSynchronize(stream);  /* ensure counters are 0 before classifiers run */
+        // cudaStreamSynchronize(stream);  /* ensure counters are 0 before classifiers run */
 
         executeSpherePipelineBinning(d_spheres, m_sphereCount, d_depthBuffer, outputImage, &m_sphereResources, stream);
-        executeCylinderPipelineBinning(d_cylinders, m_cylinderCount, d_depthBuffer, outputImage, &m_cylinderResources, stream);
+        // executeCylinderPipelineBinning(d_cylinders, m_cylinderCount, d_depthBuffer, outputImage, &m_cylinderResources, stream);
 
         nvtxRangePop();
     }
@@ -251,7 +279,7 @@ int main(int argc, char* argv[]) {
 
         Frustum frustum(camera);
         pipeline.executeFrame(d_spheres, d_cylinders, depthBuffer, outputSurface, camera, frustum, stream);
-        cudaStreamSynchronize(stream);
+        cudaStreamSynchronize(stream);  // ensure all kernels and D2H copies finish before reading stats
 
         pipeline.getSphereStats(&sphereFrustum, &sphereSmall, &sphereLarge);
         pipeline.getCylinderStats(&cylFrustum, &cylSmall, &cylLarge);
@@ -265,8 +293,8 @@ int main(int argc, char* argv[]) {
     }
 
     cudaStreamDestroy(stream);
-    texWrapper.cudaDestroySurfaceObj();
     texWrapper.cudaUnmapResources();
+    texWrapper.cudaDestroySurfaceObj();
     sphereBufferCUDA.cudaUnmapResources();
     cylinderBufferCUDA.cudaUnmapResources();
     std::cout << "Done." << std::endl;

--- a/executables/cuda_hybrid_binning/hybrid_binning_pipeline.cpp
+++ b/executables/cuda_hybrid_binning/hybrid_binning_pipeline.cpp
@@ -164,6 +164,10 @@ public:
         getCylinderBinningStats(&m_cylinderResources, frustumPassed, smallCount, largeCount);
     }
 
+    void setSmallEntityThreshold(int threshold) {
+        m_config.smallEntityThreshold = threshold;
+    }
+
 private:
     HybridBinningConfig m_config;
     int m_sphereCount = 0;
@@ -266,6 +270,12 @@ int main(int argc, char* argv[]) {
     window.setupCameraGui("Camera Info", &camera);
     window.setupInputInfoGui("Input Info");
     window.setupBenchmarkInfoGui("Benchmark", &benchmark);
+
+    int tileSize = TILE_SIZE;
+    int maxEntitiesPerTile = config.avgEntitiesPerTile;
+    window.setupPipelineConfigGui("Pipeline Config",
+        config.smallEntityThreshold, tileSize,
+        maxEntitiesPerTile, config.tilesX, config.tilesY);
 
     cudaStream_t stream;
     cudaStreamCreate(&stream);

--- a/executables/cuda_hybrid_binning/hybrid_binning_pipeline.cpp
+++ b/executables/cuda_hybrid_binning/hybrid_binning_pipeline.cpp
@@ -1,0 +1,271 @@
+/**
+ * @file hybrid_binning_pipeline.cpp
+ * @brief Hybrid CUDA pipeline with binning-by-sort (no linked lists).
+ * Uses CUB DeviceRadixSort + DeviceRunLengthEncode for tile binning.
+ */
+
+#include <iostream>
+#include <memory>
+#include <vector>
+#include <unordered_map>
+
+#include <glm/glm.hpp>
+#include <glad/glad.h>
+#include <SDL3/SDL.h>
+#include <cuda_runtime.h>
+#include <nvtx3/nvToolsExt.h>
+
+#include "appSDLGL.h"
+#include "geometry/cylinder/cylinder.h"
+#include "utils/parallel/aux_functions.h"
+#include "utils/benchmark_resources.h"
+#include "utils/scene_config_loader.h"
+#include "ux/input.h"
+#include "ux/camera.h"
+#include "ux/camera_controller.h"
+#include "algorithms/frustum_cull.h"
+#include "ux/cinematic/benchmark.h"
+#include "ux/profiler/profiler.h"
+#include "vis/gl/frame_buffer.h"
+#include "vis/gl/storage_buffer.h"
+#include "vis/gl/cu/storage_buffer_cu.h"
+#include "vis/gl/texture.h"
+#include "vis/gl/cu/canvas_cu.h"
+
+#include "../../kernels/hybrid_binning/hybrid_binning_types.h"
+#include "../../kernels/hybrid_binning/sphere_pipeline_binning.cuh"
+#include "../../kernels/hybrid_binning/cylinder_pipeline_binning.cuh"
+
+using uint = unsigned int;
+
+struct HybridBinningConfig {
+    int screenWidth = 1024;
+    int screenHeight = 1024;
+    int sphereCount = 0;
+    int cylinderCount = 0;
+    bool shown = true;
+    int smallEntityThreshold = SMALL_ENTITY_THRESHOLD;
+    double timerDuration = 48.0;
+    int tilesX;
+    int tilesY;
+    int totalTiles;
+    void computeDerivedValues() {
+        tilesX = (screenWidth + TILE_SIZE - 1) / TILE_SIZE;
+        tilesY = (screenHeight + TILE_SIZE - 1) / TILE_SIZE;
+        totalTiles = tilesX * tilesY;
+    }
+};
+
+extern "C" void launchScreenClear(
+    cudaSurfaceObject_t outputImage,
+    unsigned int* d_depthBuffer,
+    unsigned int screenWidth,
+    unsigned int screenHeight,
+    float farPlane,
+    cudaStream_t stream);
+extern "C" void uploadHybridConstants(const HybridConstants& constants, cudaStream_t stream);
+
+class HybridBinningPipelineManager {
+public:
+    explicit HybridBinningPipelineManager(const HybridBinningConfig& config) : m_config(config) {}
+    ~HybridBinningPipelineManager() {
+        freeSphereBinningResources(&m_sphereResources);
+        freeCylinderBinningResources(&m_cylinderResources);
+    }
+
+    void initialize(int sphereCount, int cylinderCount) {
+        m_sphereCount = sphereCount;
+        m_cylinderCount = cylinderCount;
+        initSphereBinningResources(&m_sphereResources, sphereCount, m_config.tilesX, m_config.tilesY, m_config.totalTiles);
+        initCylinderBinningResources(&m_cylinderResources, cylinderCount, m_config.tilesX, m_config.tilesY, m_config.totalTiles);
+        std::cout << "Binning pipeline initialized: " << sphereCount << " spheres, " << cylinderCount << " cylinders" << std::endl;
+    }
+
+    void executeFrame(
+        const glm::vec4* d_spheres,
+        const Cylinder* d_cylinders,
+        unsigned int* d_depthBuffer,
+        cudaSurfaceObject_t outputImage,
+        Camera& camera,
+        const Frustum& frustum,
+        cudaStream_t stream)
+    {
+        nvtxRangePushA("Hybrid Binning Frame");
+        HybridConstants constants;
+        constants.view = camera.getView();
+        constants.proj = camera.getProjection();
+        constants.frustumPlanes[0] = glm::vec4(frustum.topFace.normal, frustum.topFace.distance);
+        constants.frustumPlanes[1] = glm::vec4(frustum.bottomFace.normal, frustum.bottomFace.distance);
+        constants.frustumPlanes[2] = glm::vec4(frustum.rightFace.normal, frustum.rightFace.distance);
+        constants.frustumPlanes[3] = glm::vec4(frustum.leftFace.normal, frustum.leftFace.distance);
+        constants.frustumPlanes[4] = glm::vec4(frustum.farFace.normal, frustum.farFace.distance);
+        constants.frustumPlanes[5] = glm::vec4(frustum.nearFace.normal, frustum.nearFace.distance);
+        constants.front = camera.getFront();
+        constants.up = camera.getUp();
+        constants.right = camera.getRight();
+        constants.cameraPos = camera.getPosition();
+        constants.screenWidth = m_config.screenWidth;
+        constants.screenHeight = m_config.screenHeight;
+        constants.fov = camera.getFov();
+        constants.sphereCount = m_sphereCount;
+        constants.cylinderCount = m_cylinderCount;
+        constants.tilesX = m_config.tilesX;
+        constants.tilesY = m_config.tilesY;
+        constants.totalTiles = m_config.totalTiles;
+        constants.smallEntityThreshold = m_config.smallEntityThreshold;
+        constants.benchmark = 1;
+        uploadHybridConstants(constants, stream);
+
+        resetSphereBinningCounters(&m_sphereResources, stream);
+        resetCylinderBinningCounters(&m_cylinderResources, stream);
+
+        launchScreenClear(outputImage, d_depthBuffer, m_config.screenWidth, m_config.screenHeight, camera.getFar(), stream);
+
+        executeSpherePipelineBinning(d_spheres, m_sphereCount, d_depthBuffer, outputImage, &m_sphereResources, stream);
+        executeCylinderPipelineBinning(d_cylinders, m_cylinderCount, d_depthBuffer, outputImage, &m_cylinderResources, stream);
+
+        nvtxRangePop();
+    }
+
+    void getSphereStats(unsigned int* frustumPassed, unsigned int* smallCount, unsigned int* largeCount) {
+        getSphereBinningStats(&m_sphereResources, frustumPassed, smallCount, largeCount);
+    }
+    void getCylinderStats(unsigned int* frustumPassed, unsigned int* smallCount, unsigned int* largeCount) {
+        getCylinderBinningStats(&m_cylinderResources, frustumPassed, smallCount, largeCount);
+    }
+
+private:
+    HybridBinningConfig m_config;
+    int m_sphereCount = 0;
+    int m_cylinderCount = 0;
+    SphereBinningResources m_sphereResources;
+    CylinderBinningResources m_cylinderResources;
+};
+
+HybridBinningConfig loadConfiguration() {
+    HybridBinningConfig config;
+    SceneSettings settings = SceneConfigLoader::loadDefault();
+    SceneConfigLoader::applyToGlobals(settings);
+    config.screenWidth = settings.screenWidth;
+    config.screenHeight = settings.screenHeight;
+    config.sphereCount = settings.sphereCount;
+    config.cylinderCount = settings.cylinderCount;
+    config.timerDuration = settings.timerDuration;
+    config.smallEntityThreshold = SMALL_ENTITY_THRESHOLD;
+    config.computeDerivedValues();
+    return config;
+}
+
+int main(int argc, char* argv[]) {
+    std::cout << "=============================================" << std::endl;
+    std::cout << "  Hybrid CUDA Binning Pipeline              " << std::endl;
+    std::cout << "  (Sort-based tile binning, no linked lists)" << std::endl;
+    std::cout << "=============================================" << std::endl;
+
+    HybridBinningConfig config = loadConfiguration();
+    std::cout << "Screen: " << config.screenWidth << "x" << config.screenHeight
+              << "  Tiles: " << config.tilesX << "x" << config.tilesY << std::endl;
+
+    int deviceCount = 0;
+    cudaGetDeviceCount(&deviceCount);
+    if (deviceCount == 0) {
+        std::cerr << "No CUDA devices found." << std::endl;
+        return 1;
+    }
+    cudaSetDevice(0);
+
+    AppOpenGL window("Hybrid CUDA Binning", config.screenWidth, config.screenHeight, config.shown);
+    Camera camera(config.screenWidth, config.screenHeight);
+    camera.SetPosition(0.0f, 0.0f, 0.0f);
+    CameraController cameraController(window, camera);
+
+    std::vector<Sphere> spheres;
+    std::vector<Cylinder> cylinders;
+    getCompleteScene(spheres, config.sphereCount, cylinders, config.cylinderCount);
+    config.sphereCount = static_cast<int>(spheres.size());
+    config.cylinderCount = static_cast<int>(cylinders.size());
+    std::cout << "Scene: " << config.sphereCount << " spheres, " << config.cylinderCount << " cylinders" << std::endl;
+
+    std::vector<std::pair<glm::vec3, glm::vec3>> checkpoints = getCheckpoints(config.sphereCount, spheres, cylinders);
+    CanvasCUDA canvas(GL_TEXTURE_2D, GL_RGBA8, config.screenWidth, config.screenHeight);
+    canvas.setFBO(GL_COLOR_ATTACHMENT0);
+    canvas.setupDepthDataCUDA(config.screenWidth, config.screenHeight);
+
+    TextureCUDAWrapper& texWrapper = canvas.getCUDATextureWrapper();
+    texWrapper.cudaMapResources();
+    texWrapper.cudaCreateSurfaceObj();
+    cudaSurfaceObject_t outputSurface = texWrapper.getSurfaceObject();
+    unsigned int* depthBuffer = canvas.getDepthDataCUDA().getDepthBuffer();
+
+    StorageBuffer sphereBuffer(GL_SHADER_STORAGE_BUFFER, config.sphereCount * sizeof(Sphere), 6, spheres.data(), GL_STATIC_DRAW);
+    StorageBufferCUDAWrapper sphereBufferCUDA(sphereBuffer);
+    sphereBufferCUDA.cudaMapResources();
+    glm::vec4* d_spheres = sphereBufferCUDA.getDevicePointer<glm::vec4>();
+
+    StorageBuffer cylinderBuffer(GL_SHADER_STORAGE_BUFFER, config.cylinderCount * sizeof(Cylinder), 7, cylinders.data(), GL_STATIC_DRAW);
+    StorageBufferCUDAWrapper cylinderBufferCUDA(cylinderBuffer);
+    cylinderBufferCUDA.cudaMapResources();
+    Cylinder* d_cylinders = cylinderBufferCUDA.getDevicePointer<Cylinder>();
+
+    spheres.clear();
+    cylinders.clear();
+
+    HybridBinningPipelineManager pipeline(config);
+    pipeline.initialize(config.sphereCount, config.cylinderCount);
+
+    Benchmark benchmark(cameraController, checkpoints);
+    int visibleSpheres = config.sphereCount, drawnSpheres = config.sphereCount;
+    int visibleCylinders = config.cylinderCount, drawnCylinders = config.cylinderCount;
+    unsigned int sphereFrustum = 0, sphereSmall = 0, sphereLarge = 0;
+    unsigned int cylFrustum = 0, cylSmall = 0, cylLarge = 0;
+    Profiler profiler(window, "media/csv/cuda_hybrid_binning/frame_times.csv",
+                      "media/csv/cuda_hybrid_binning/process_times.csv",
+                      config.sphereCount, config.cylinderCount, 0, config.timerDuration);
+
+    window.setupSceneInfoGui("Scene Info", {
+        {"Screen width", &config.screenWidth},
+        {"Screen height", &config.screenHeight},
+        {"Sphere count", &config.sphereCount},
+        {"Visible spheres", &visibleSpheres},
+        {"Drawn spheres", &drawnSpheres},
+        {"Cylinder count", &config.cylinderCount},
+        {"Visible cylinders", &visibleCylinders},
+        {"Drawn cylinders", &drawnCylinders}
+    });
+    window.setupCameraGui("Camera Info", &camera);
+    window.setupInputInfoGui("Input Info");
+    window.setupBenchmarkInfoGui("Benchmark", &benchmark);
+
+    cudaStream_t stream;
+    cudaStreamCreate(&stream);
+
+    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
+    bool isRunning = true;
+    while (isRunning) {
+        cameraController.cameraUpdate();
+        benchmark.update();
+        profiler.updateProfiler(benchmark.getCheckpointID(), visibleSpheres, drawnSpheres, visibleCylinders, drawnCylinders);
+
+        Frustum frustum(camera);
+        pipeline.executeFrame(d_spheres, d_cylinders, depthBuffer, outputSurface, camera, frustum, stream);
+        cudaStreamSynchronize(stream);
+
+        pipeline.getSphereStats(&sphereFrustum, &sphereSmall, &sphereLarge);
+        pipeline.getCylinderStats(&cylFrustum, &cylSmall, &cylLarge);
+        visibleSpheres = static_cast<int>(sphereFrustum);
+        drawnSpheres = static_cast<int>(sphereSmall + sphereLarge);
+        visibleCylinders = static_cast<int>(cylFrustum);
+        drawnCylinders = static_cast<int>(cylSmall + cylLarge);
+
+        glBindFramebuffer(GL_READ_FRAMEBUFFER, canvas.getFramebuffer().getId());
+        isRunning = window.update();
+    }
+
+    cudaStreamDestroy(stream);
+    texWrapper.cudaDestroySurfaceObj();
+    texWrapper.cudaUnmapResources();
+    sphereBufferCUDA.cudaUnmapResources();
+    cylinderBufferCUDA.cudaUnmapResources();
+    std::cout << "Done." << std::endl;
+    return 0;
+}

--- a/kernels/hybrid_binning/cylinder_pipeline_binning.cu
+++ b/kernels/hybrid_binning/cylinder_pipeline_binning.cu
@@ -147,14 +147,14 @@ void executeCylinderPipelineBinning(
     cudaMemcpyAsync(r->h_smallCount, r->d_smallCount, sizeof(unsigned int), cudaMemcpyDeviceToHost, stream);
     cudaMemcpyAsync(r->h_pairCount, r->d_pairCount, sizeof(unsigned int), cudaMemcpyDeviceToHost, stream);
     cudaMemcpyAsync(r->h_frustumPassedCount, r->d_frustumPassedCount, sizeof(unsigned int), cudaMemcpyDeviceToHost, stream);
-    cudaStreamSynchronize(stream);
+    // cudaStreamSynchronize(stream);
 
     unsigned int smallCount = *r->h_smallCount;
     unsigned int numPairs = *r->h_pairCount;
 
     if (numPairs > 0) {
         
-        cudaStreamSynchronize(stream);
+        // cudaStreamSynchronize(stream);
         if (numPairs > (unsigned int)r->maxPairs) numPairs = r->maxPairs;
 
         sortPairs64AndBuildTileOffsets(

--- a/kernels/hybrid_binning/cylinder_pipeline_binning.cu
+++ b/kernels/hybrid_binning/cylinder_pipeline_binning.cu
@@ -5,6 +5,7 @@
 
 #include <cuda_runtime.h>
 #include <cstdio>
+#include <cstdint>
 #include <cub/cub.cuh>
 #include "cylinder_pipeline_binning.cuh"
 #include "hybrid_binning_types.h"
@@ -14,28 +15,29 @@ extern "C" void launchCylinderFrustumBBoxClassify(
     const Cylinder* d_cylinders,
     unsigned int* d_smallCylinderIndices,
     unsigned int* d_smallCylinderCount,
-    CylinderBillboard* d_largeBillboards,
-    unsigned int* d_largeCylinderCount,
+    unsigned long long* d_tile_entity_pairs,
+    unsigned int* d_pair_count,
     unsigned int* d_frustumPassedCount,
     int cylinderCount,
+    int maxPairs,
     cudaStream_t stream);
-extern "C" void launchGenerateCylinderPairs(
-    const CylinderBillboard* d_billboards,
-    unsigned int billboardCount,
-    unsigned int* d_keys,
-    unsigned int* d_values,
-    unsigned int* d_pairCount,
-    cudaStream_t stream);
-extern "C" void sortPairsAndBuildTileOffsets(
-    unsigned int* d_keys_in, unsigned int* d_values_in,
-    unsigned int* d_keys_out, unsigned int* d_values_out,
-    unsigned int num_pairs, unsigned int total_tiles,
+extern "C" void sortPairs64AndBuildTileOffsets(
+    unsigned long long* d_pairs_in,
+    unsigned long long* d_pairs_out,
+    unsigned int num_pairs,
+    unsigned int total_tiles,
+    unsigned int* d_keys_extract,
     unsigned int* d_tile_offsets,
-    unsigned int* d_unique_out, unsigned int* d_counts_out,
-    unsigned int* d_run_offsets, unsigned int* d_num_runs,
-    void* d_temp_sort, size_t temp_sort_bytes_sort,
-    void* d_temp_rle, size_t temp_rle_bytes,
-    void* d_temp_scan, size_t temp_scan_bytes,
+    unsigned int* d_unique_out,
+    unsigned int* d_counts_out,
+    unsigned int* d_run_offsets,
+    unsigned int* d_num_runs,
+    void* d_temp_sort64,
+    size_t temp_sort64_bytes,
+    void* d_temp_rle,
+    size_t temp_rle_bytes,
+    void* d_temp_scan,
+    size_t temp_scan_bytes,
     cudaStream_t stream);
 extern "C" void buildTileOffsetsFromRLE(
     const unsigned int* d_unique_out, const unsigned int* d_counts_out,
@@ -52,57 +54,53 @@ extern "C" void launchSmallCylinderRaster(
     cudaSurfaceObject_t outputImage, cudaStream_t stream);
 extern "C" void launchTiledCylinderRasterBinning(
     const Cylinder* d_cylinders, const unsigned int* d_tile_offsets,
-    const unsigned int* d_sorted_entity_indices,
+    const unsigned long long* d_tile_entity_pairs_sorted,
     unsigned int* d_depthBuffer, cudaSurfaceObject_t outputImage,
     unsigned int tilesX, unsigned int tilesY, cudaStream_t stream);
 
 #define CUDA_CHECK(call) do { cudaError_t e = call; if (e != cudaSuccess) printf("CUDA error %d: %s\n", e, cudaGetErrorString(e)); } while(0)
 
-void initCylinderBinningResources(CylinderBinningResources* r, int maxCylinders, int tilesX, int tilesY, int totalTiles) {
+void initCylinderBinningResources(CylinderBinningResources* r, int maxCylinders, int tilesX, int tilesY, int totalTiles, int avgEntitiesPerTile) {
     cudaGetLastError();
     r->maxCylinders = maxCylinders;
     r->tilesX = tilesX;
     r->tilesY = tilesY;
     r->totalTiles = totalTiles;
-    r->maxPairs = maxCylinders * 64;
+    int avgPerTile = (avgEntitiesPerTile > 0) ? avgEntitiesPerTile : AVG_ENTITIES_PER_TILE;
+    r->maxPairs = avgPerTile * totalTiles;
     if (r->maxPairs < totalTiles * 4) r->maxPairs = totalTiles * 4;
 
     CUDA_CHECK(cudaMalloc(&r->d_smallIndices, maxCylinders * sizeof(unsigned int)));
     CUDA_CHECK(cudaMalloc(&r->d_smallCount, sizeof(unsigned int)));
-    CUDA_CHECK(cudaMalloc(&r->d_largeCount, sizeof(unsigned int)));
-    CUDA_CHECK(cudaMalloc(&r->d_largeBillboards, maxCylinders * sizeof(CylinderBillboard)));
     CUDA_CHECK(cudaMalloc(&r->d_frustumPassedCount, sizeof(unsigned int)));
     CUDA_CHECK(cudaHostAlloc(&r->h_smallCount, sizeof(unsigned int), cudaHostAllocDefault));
-    CUDA_CHECK(cudaHostAlloc(&r->h_largeCount, sizeof(unsigned int), cudaHostAllocDefault));
+    CUDA_CHECK(cudaHostAlloc(&r->h_pairCount, sizeof(unsigned int), cudaHostAllocDefault));
     CUDA_CHECK(cudaHostAlloc(&r->h_frustumPassedCount, sizeof(unsigned int), cudaHostAllocDefault));
 
     CUDA_CHECK(cudaMalloc(&r->d_pairCount, sizeof(unsigned int)));
-    CUDA_CHECK(cudaMalloc(&r->d_keys_in, r->maxPairs * sizeof(unsigned int)));
-    CUDA_CHECK(cudaMalloc(&r->d_values_in, r->maxPairs * sizeof(unsigned int)));
-    CUDA_CHECK(cudaMalloc(&r->d_keys_out, r->maxPairs * sizeof(unsigned int)));
-    CUDA_CHECK(cudaMalloc(&r->d_values_out, r->maxPairs * sizeof(unsigned int)));
+    CUDA_CHECK(cudaMalloc(&r->d_tile_entity_pairs, r->maxPairs * sizeof(unsigned long long)));
+    CUDA_CHECK(cudaMalloc(&r->d_tile_entity_pairs_sorted, r->maxPairs * sizeof(unsigned long long)));
+    CUDA_CHECK(cudaMalloc(&r->d_keys_extract, r->maxPairs * sizeof(unsigned int)));
     CUDA_CHECK(cudaMalloc(&r->d_tile_offsets, (totalTiles + 1) * sizeof(unsigned int)));
     CUDA_CHECK(cudaMalloc(&r->d_unique_out, r->maxPairs * sizeof(unsigned int)));
     CUDA_CHECK(cudaMalloc(&r->d_counts_out, r->maxPairs * sizeof(unsigned int)));
     CUDA_CHECK(cudaMalloc(&r->d_run_offsets, r->maxPairs * sizeof(unsigned int)));
     CUDA_CHECK(cudaMalloc(&r->d_num_runs, sizeof(unsigned int)));
 
-    r->d_temp_sort = nullptr;
+    r->d_temp_sort64 = nullptr;
+    r->temp_sort64_bytes = 0;
+    cub::DeviceRadixSort::SortKeys(nullptr, r->temp_sort64_bytes,
+        (unsigned long long*)nullptr, (unsigned long long*)nullptr, (int)r->maxPairs, 0, 64);
     r->d_temp_rle = nullptr;
     r->d_temp_scan = nullptr;
-    r->temp_sort_bytes = 0;
     r->temp_rle_bytes = 0;
     r->temp_scan_bytes = 0;
-    sortPairsAndBuildTileOffsets(
-        r->d_keys_in, r->d_values_in, r->d_keys_out, r->d_values_out,
-        1, totalTiles, r->d_tile_offsets, r->d_unique_out, r->d_counts_out,
-        r->d_run_offsets, r->d_num_runs,
-        nullptr, r->temp_sort_bytes, nullptr, r->temp_rle_bytes,
-        nullptr, r->temp_scan_bytes, nullptr);
-    size_t scan_bytes = 0;
-    cub::DeviceScan::ExclusiveSum(nullptr, scan_bytes, (unsigned int*)nullptr, (unsigned int*)nullptr, (int)r->maxPairs);
-    if (scan_bytes > r->temp_scan_bytes) r->temp_scan_bytes = scan_bytes;
-    if (r->temp_sort_bytes > 0) CUDA_CHECK(cudaMalloc(&r->d_temp_sort, r->temp_sort_bytes));
+    cub::DeviceRunLengthEncode::Encode(nullptr, r->temp_rle_bytes,
+        (unsigned int*)nullptr, (unsigned int*)nullptr, (unsigned int*)nullptr,
+        (unsigned int*)nullptr, (int)r->maxPairs);
+    cub::DeviceScan::ExclusiveSum(nullptr, r->temp_scan_bytes,
+        (unsigned int*)nullptr, (unsigned int*)nullptr, (int)r->maxPairs);
+    if (r->temp_sort64_bytes > 0) CUDA_CHECK(cudaMalloc(&r->d_temp_sort64, r->temp_sort64_bytes));
     if (r->temp_rle_bytes > 0) CUDA_CHECK(cudaMalloc(&r->d_temp_rle, r->temp_rle_bytes));
     if (r->temp_scan_bytes > 0) CUDA_CHECK(cudaMalloc(&r->d_temp_scan, r->temp_scan_bytes));
 }
@@ -111,31 +109,28 @@ void freeCylinderBinningResources(CylinderBinningResources* r) {
     if (!r) return;
     cudaFree(r->d_smallIndices);
     cudaFree(r->d_smallCount);
-    cudaFree(r->d_largeCount);
-    cudaFree(r->d_largeBillboards);
     cudaFree(r->d_frustumPassedCount);
     cudaFreeHost(r->h_smallCount);
-    cudaFreeHost(r->h_largeCount);
+    cudaFreeHost(r->h_pairCount);
     cudaFreeHost(r->h_frustumPassedCount);
     cudaFree(r->d_pairCount);
-    cudaFree(r->d_keys_in);
-    cudaFree(r->d_values_in);
-    cudaFree(r->d_keys_out);
-    cudaFree(r->d_values_out);
+    cudaFree(r->d_tile_entity_pairs);
+    cudaFree(r->d_tile_entity_pairs_sorted);
+    cudaFree(r->d_keys_extract);
     cudaFree(r->d_tile_offsets);
     cudaFree(r->d_unique_out);
     cudaFree(r->d_counts_out);
     cudaFree(r->d_run_offsets);
     cudaFree(r->d_num_runs);
-    if (r->d_temp_sort) cudaFree(r->d_temp_sort);
+    if (r->d_temp_sort64) cudaFree(r->d_temp_sort64);
     if (r->d_temp_rle) cudaFree(r->d_temp_rle);
     if (r->d_temp_scan) cudaFree(r->d_temp_scan);
 }
 
 void resetCylinderBinningCounters(CylinderBinningResources* r, cudaStream_t stream) {
     cudaMemsetAsync(r->d_smallCount, 0, sizeof(unsigned int), stream);
-    cudaMemsetAsync(r->d_largeCount, 0, sizeof(unsigned int), stream);
     cudaMemsetAsync(r->d_frustumPassedCount, 0, sizeof(unsigned int), stream);
+    cudaMemsetAsync(r->d_pairCount, 0, sizeof(unsigned int), stream);
 }
 
 void executeCylinderPipelineBinning(
@@ -150,36 +145,34 @@ void executeCylinderPipelineBinning(
 
     launchCylinderFrustumBBoxClassify(
         d_cylinders, r->d_smallIndices, r->d_smallCount,
-        r->d_largeBillboards, r->d_largeCount, r->d_frustumPassedCount,
-        cylinderCount, stream);
+        r->d_tile_entity_pairs, r->d_pairCount, r->d_frustumPassedCount,
+        cylinderCount, r->maxPairs, stream);
 
     cudaMemcpyAsync(r->h_smallCount, r->d_smallCount, sizeof(unsigned int), cudaMemcpyDeviceToHost, stream);
-    cudaMemcpyAsync(r->h_largeCount, r->d_largeCount, sizeof(unsigned int), cudaMemcpyDeviceToHost, stream);
+    cudaMemcpyAsync(r->h_pairCount, r->d_pairCount, sizeof(unsigned int), cudaMemcpyDeviceToHost, stream);
     cudaMemcpyAsync(r->h_frustumPassedCount, r->d_frustumPassedCount, sizeof(unsigned int), cudaMemcpyDeviceToHost, stream);
     cudaStreamSynchronize(stream);
 
     unsigned int smallCount = *r->h_smallCount;
-    unsigned int largeCount = *r->h_largeCount;
+    unsigned int numPairs = *r->h_pairCount;
 
-    if (largeCount > 0) {
-        launchGenerateCylinderPairs(
-            r->d_largeBillboards, largeCount,
-            r->d_keys_in, r->d_values_in, r->d_pairCount, stream);
-        unsigned int numPairs;
-        cudaMemcpyAsync(&numPairs, r->d_pairCount, sizeof(unsigned int), cudaMemcpyDeviceToHost, stream);
+    if (numPairs > 0) {
+        
         cudaStreamSynchronize(stream);
         if (numPairs > (unsigned int)r->maxPairs) numPairs = r->maxPairs;
 
-        sortPairsAndBuildTileOffsets(
-            r->d_keys_in, r->d_values_in, r->d_keys_out, r->d_values_out,
-            numPairs, r->totalTiles, r->d_tile_offsets,
+        sortPairs64AndBuildTileOffsets(
+            r->d_tile_entity_pairs, r->d_tile_entity_pairs_sorted,
+            numPairs, r->totalTiles,
+            r->d_keys_extract, r->d_tile_offsets,
             r->d_unique_out, r->d_counts_out, r->d_run_offsets, r->d_num_runs,
-            r->d_temp_sort, r->temp_sort_bytes,
+            r->d_temp_sort64, r->temp_sort64_bytes,
             r->d_temp_rle, r->temp_rle_bytes,
             r->d_temp_scan, r->temp_scan_bytes, stream);
         unsigned int numRuns;
         cudaMemcpyAsync(&numRuns, r->d_num_runs, sizeof(unsigned int), cudaMemcpyDeviceToHost, stream);
         cudaStreamSynchronize(stream);
+        if (numRuns > numPairs) numRuns = numPairs;
 
         buildTileOffsetsFromRLE(
             r->d_unique_out, r->d_counts_out, numRuns, numPairs, r->totalTiles,
@@ -196,9 +189,9 @@ void executeCylinderPipelineBinning(
         launchSmallCylinderRaster(d_cylinders, r->d_smallIndices, smallCount, d_depthBuffer, outputImage, stream);
     }
 
-    if (largeCount > 0) {
+    if (numPairs > 0) {
         launchTiledCylinderRasterBinning(
-            d_cylinders, r->d_tile_offsets, r->d_values_out,
+            d_cylinders, r->d_tile_offsets, r->d_tile_entity_pairs_sorted,
             d_depthBuffer, outputImage, r->tilesX, r->tilesY, stream);
     }
 }
@@ -208,5 +201,5 @@ void getCylinderBinningStats(CylinderBinningResources* r,
 {
     if (outFrustumPassed) *outFrustumPassed = *r->h_frustumPassedCount;
     if (outSmallCount) *outSmallCount = *r->h_smallCount;
-    if (outLargeCount) *outLargeCount = *r->h_largeCount;
+    if (outLargeCount) *outLargeCount = *r->h_pairCount;
 }

--- a/kernels/hybrid_binning/cylinder_pipeline_binning.cu
+++ b/kernels/hybrid_binning/cylinder_pipeline_binning.cu
@@ -26,7 +26,6 @@ extern "C" void sortPairs64AndBuildTileOffsets(
     unsigned long long* d_pairs_out,
     unsigned int num_pairs,
     unsigned int total_tiles,
-    unsigned int* d_keys_extract,
     unsigned int* d_tile_offsets,
     unsigned int* d_unique_out,
     unsigned int* d_counts_out,
@@ -39,6 +38,7 @@ extern "C" void sortPairs64AndBuildTileOffsets(
     void* d_temp_scan,
     size_t temp_scan_bytes,
     cudaStream_t stream);
+extern "C" void getRleTempStorageBytesForPairs64(size_t* out_bytes, int maxPairs);
 extern "C" void buildTileOffsetsFromRLE(
     const unsigned int* d_unique_out, const unsigned int* d_counts_out,
     unsigned int num_runs, unsigned int num_pairs, unsigned int total_tiles,
@@ -80,7 +80,6 @@ void initCylinderBinningResources(CylinderBinningResources* r, int maxCylinders,
     CUDA_CHECK(cudaMalloc(&r->d_pairCount, sizeof(unsigned int)));
     CUDA_CHECK(cudaMalloc(&r->d_tile_entity_pairs, r->maxPairs * sizeof(unsigned long long)));
     CUDA_CHECK(cudaMalloc(&r->d_tile_entity_pairs_sorted, r->maxPairs * sizeof(unsigned long long)));
-    CUDA_CHECK(cudaMalloc(&r->d_keys_extract, r->maxPairs * sizeof(unsigned int)));
     CUDA_CHECK(cudaMalloc(&r->d_tile_offsets, (totalTiles + 1) * sizeof(unsigned int)));
     CUDA_CHECK(cudaMalloc(&r->d_unique_out, r->maxPairs * sizeof(unsigned int)));
     CUDA_CHECK(cudaMalloc(&r->d_counts_out, r->maxPairs * sizeof(unsigned int)));
@@ -95,9 +94,7 @@ void initCylinderBinningResources(CylinderBinningResources* r, int maxCylinders,
     r->d_temp_scan = nullptr;
     r->temp_rle_bytes = 0;
     r->temp_scan_bytes = 0;
-    cub::DeviceRunLengthEncode::Encode(nullptr, r->temp_rle_bytes,
-        (unsigned int*)nullptr, (unsigned int*)nullptr, (unsigned int*)nullptr,
-        (unsigned int*)nullptr, (int)r->maxPairs);
+    getRleTempStorageBytesForPairs64(&r->temp_rle_bytes, (int)r->maxPairs);
     cub::DeviceScan::ExclusiveSum(nullptr, r->temp_scan_bytes,
         (unsigned int*)nullptr, (unsigned int*)nullptr, (int)r->maxPairs);
     if (r->temp_sort64_bytes > 0) CUDA_CHECK(cudaMalloc(&r->d_temp_sort64, r->temp_sort64_bytes));
@@ -116,7 +113,6 @@ void freeCylinderBinningResources(CylinderBinningResources* r) {
     cudaFree(r->d_pairCount);
     cudaFree(r->d_tile_entity_pairs);
     cudaFree(r->d_tile_entity_pairs_sorted);
-    cudaFree(r->d_keys_extract);
     cudaFree(r->d_tile_offsets);
     cudaFree(r->d_unique_out);
     cudaFree(r->d_counts_out);
@@ -164,7 +160,7 @@ void executeCylinderPipelineBinning(
         sortPairs64AndBuildTileOffsets(
             r->d_tile_entity_pairs, r->d_tile_entity_pairs_sorted,
             numPairs, r->totalTiles,
-            r->d_keys_extract, r->d_tile_offsets,
+            r->d_tile_offsets,
             r->d_unique_out, r->d_counts_out, r->d_run_offsets, r->d_num_runs,
             r->d_temp_sort64, r->temp_sort64_bytes,
             r->d_temp_rle, r->temp_rle_bytes,

--- a/kernels/hybrid_binning/cylinder_pipeline_binning.cu
+++ b/kernels/hybrid_binning/cylinder_pipeline_binning.cu
@@ -39,26 +39,29 @@ extern "C" void sortPairs64AndBuildTileOffsets(
     size_t temp_scan_bytes,
     cudaStream_t stream);
 extern "C" void getRleTempStorageBytesForPairs64(size_t* out_bytes, int maxPairs);
-extern "C" void buildTileOffsetsFromRLE(
-    const unsigned int* d_unique_out, const unsigned int* d_counts_out,
-    unsigned int num_runs, unsigned int num_pairs, unsigned int total_tiles,
-    unsigned int* d_run_offsets, unsigned int* d_tile_offsets,
-    void* d_temp_scan, size_t temp_scan_bytes, cudaStream_t stream);
-extern "C" void launchScatterAndFillTileOffsets(
-    const unsigned int* d_unique_out, const unsigned int* d_run_offsets,
-    unsigned int num_runs, unsigned int num_pairs, unsigned int total_tiles,
-    unsigned int* d_tile_offsets, cudaStream_t stream);
 extern "C" void launchSmallCylinderRaster(
     const Cylinder* d_cylinders, const unsigned int* d_smallCylinderIndices,
     unsigned int smallCylinderCount, unsigned int* d_depthBuffer,
     cudaSurfaceObject_t outputImage, cudaStream_t stream);
-extern "C" void launchTiledCylinderRasterBinning(
-    const Cylinder* d_cylinders, const unsigned int* d_tile_offsets,
+extern "C" void launchExpandWorkGroups(
+    const unsigned int* d_unique_out,
+    const unsigned int* d_counts_out,
+    const unsigned int* d_run_offsets,
+    unsigned int numRuns,
+    unsigned int* d_wg_tileId,
+    unsigned int* d_wg_entityStart,
+    unsigned int* d_wg_entityCount,
+    unsigned int* d_wg_totalCount,
+    cudaStream_t stream);
+extern "C" void launchTiledCylinderRasterWG(
+    const Cylinder* d_cylinders,
     const unsigned long long* d_tile_entity_pairs_sorted,
-    unsigned int* d_depthBuffer, cudaSurfaceObject_t outputImage,
-    unsigned int tilesX, unsigned int tilesY,
-    unsigned int* d_lightTileList, unsigned int* d_heavyTileIndices,
-    unsigned int* d_heavyBatchStarts, unsigned int* d_tileClassifyCounts,
+    const unsigned int* d_wg_tileId,
+    const unsigned int* d_wg_entityStart,
+    const unsigned int* d_wg_entityCount,
+    unsigned int totalWorkGroups,
+    unsigned int* d_depthBuffer,
+    cudaSurfaceObject_t outputImage,
     cudaStream_t stream);
 
 #define CUDA_CHECK(call) do { cudaError_t e = call; if (e != cudaSuccess) printf("CUDA error %d: %s\n", e, cudaGetErrorString(e)); } while(0)
@@ -103,7 +106,14 @@ void initCylinderBinningResources(CylinderBinningResources* r, int maxCylinders,
     if (r->temp_sort64_bytes > 0) CUDA_CHECK(cudaMalloc(&r->d_temp_sort64, r->temp_sort64_bytes));
     if (r->temp_rle_bytes > 0) CUDA_CHECK(cudaMalloc(&r->d_temp_rle, r->temp_rle_bytes));
     if (r->temp_scan_bytes > 0) CUDA_CHECK(cudaMalloc(&r->d_temp_scan, r->temp_scan_bytes));
-    CUDA_CHECK(cudaMalloc(&r->d_tileClassifyCounts, 2 * sizeof(unsigned int)));
+
+    // Work-group expansion buffers
+    r->maxWorkGroups = r->maxPairs / SHARED_BATCH_SIZE + totalTiles;
+    CUDA_CHECK(cudaMalloc(&r->d_wg_tileId, r->maxWorkGroups * sizeof(unsigned int)));
+    CUDA_CHECK(cudaMalloc(&r->d_wg_entityStart, r->maxWorkGroups * sizeof(unsigned int)));
+    CUDA_CHECK(cudaMalloc(&r->d_wg_entityCount, r->maxWorkGroups * sizeof(unsigned int)));
+    CUDA_CHECK(cudaMalloc(&r->d_wg_totalCount, sizeof(unsigned int)));
+    CUDA_CHECK(cudaHostAlloc(&r->h_wg_totalCount, sizeof(unsigned int), cudaHostAllocDefault));
 }
 
 void freeCylinderBinningResources(CylinderBinningResources* r) {
@@ -125,7 +135,11 @@ void freeCylinderBinningResources(CylinderBinningResources* r) {
     if (r->d_temp_sort64) cudaFree(r->d_temp_sort64);
     if (r->d_temp_rle) cudaFree(r->d_temp_rle);
     if (r->d_temp_scan) cudaFree(r->d_temp_scan);
-    cudaFree(r->d_tileClassifyCounts);
+    cudaFree(r->d_wg_tileId);
+    cudaFree(r->d_wg_entityStart);
+    cudaFree(r->d_wg_entityCount);
+    cudaFree(r->d_wg_totalCount);
+    cudaFreeHost(r->h_wg_totalCount);
 }
 
 void resetCylinderBinningCounters(CylinderBinningResources* r, cudaStream_t stream) {
@@ -175,27 +189,36 @@ void executeCylinderPipelineBinning(
         cudaStreamSynchronize(stream);
         if (numRuns > numPairs) numRuns = numPairs;
 
-        buildTileOffsetsFromRLE(
-            r->d_unique_out, r->d_counts_out, numRuns, numPairs, r->totalTiles,
-            r->d_run_offsets, r->d_tile_offsets,
-            r->d_temp_scan, r->temp_scan_bytes, stream);
-        launchScatterAndFillTileOffsets(
-            r->d_unique_out, r->d_run_offsets, numRuns, numPairs, r->totalTiles,
-            r->d_tile_offsets, stream);
-    } else {
-        cudaMemsetAsync(r->d_tile_offsets, 0, (r->totalTiles + 1) * sizeof(unsigned int), stream);
+        // ExclusiveSum on counts -> run_offsets (start of each tile's entities in sorted array)
+        cub::DeviceScan::ExclusiveSum(
+            r->d_temp_scan, r->temp_scan_bytes,
+            r->d_counts_out, r->d_run_offsets,
+            numRuns, stream);
+
+        // Expand RLE runs into work-group dispatch list
+        cudaMemsetAsync(r->d_wg_totalCount, 0, sizeof(unsigned int), stream);
+        launchExpandWorkGroups(
+            r->d_unique_out, r->d_counts_out, r->d_run_offsets, numRuns,
+            r->d_wg_tileId, r->d_wg_entityStart, r->d_wg_entityCount,
+            r->d_wg_totalCount, stream);
+
+        // Read total work groups
+        cudaMemcpyAsync(r->h_wg_totalCount, r->d_wg_totalCount,
+            sizeof(unsigned int), cudaMemcpyDeviceToHost, stream);
+        cudaStreamSynchronize(stream);
+        unsigned int totalWorkGroups = *r->h_wg_totalCount;
+
+        // Launch tiled cylinder raster
+        if (totalWorkGroups > 0) {
+            launchTiledCylinderRasterWG(
+                d_cylinders, r->d_tile_entity_pairs_sorted,
+                r->d_wg_tileId, r->d_wg_entityStart, r->d_wg_entityCount,
+                totalWorkGroups, d_depthBuffer, outputImage, stream);
+        }
     }
 
     if (smallCount > 0) {
         launchSmallCylinderRaster(d_cylinders, r->d_smallIndices, smallCount, d_depthBuffer, outputImage, stream);
-    }
-
-    if (numPairs > 0) {
-        launchTiledCylinderRasterBinning(
-            d_cylinders, r->d_tile_offsets, r->d_tile_entity_pairs_sorted,
-            d_depthBuffer, outputImage, r->tilesX, r->tilesY,
-            r->d_unique_out, r->d_counts_out, r->d_run_offsets,
-            r->d_tileClassifyCounts, stream);
     }
 }
 

--- a/kernels/hybrid_binning/cylinder_pipeline_binning.cu
+++ b/kernels/hybrid_binning/cylinder_pipeline_binning.cu
@@ -56,7 +56,10 @@ extern "C" void launchTiledCylinderRasterBinning(
     const Cylinder* d_cylinders, const unsigned int* d_tile_offsets,
     const unsigned long long* d_tile_entity_pairs_sorted,
     unsigned int* d_depthBuffer, cudaSurfaceObject_t outputImage,
-    unsigned int tilesX, unsigned int tilesY, cudaStream_t stream);
+    unsigned int tilesX, unsigned int tilesY,
+    unsigned int* d_lightTileList, unsigned int* d_heavyTileIndices,
+    unsigned int* d_heavyBatchStarts, unsigned int* d_tileClassifyCounts,
+    cudaStream_t stream);
 
 #define CUDA_CHECK(call) do { cudaError_t e = call; if (e != cudaSuccess) printf("CUDA error %d: %s\n", e, cudaGetErrorString(e)); } while(0)
 
@@ -100,6 +103,7 @@ void initCylinderBinningResources(CylinderBinningResources* r, int maxCylinders,
     if (r->temp_sort64_bytes > 0) CUDA_CHECK(cudaMalloc(&r->d_temp_sort64, r->temp_sort64_bytes));
     if (r->temp_rle_bytes > 0) CUDA_CHECK(cudaMalloc(&r->d_temp_rle, r->temp_rle_bytes));
     if (r->temp_scan_bytes > 0) CUDA_CHECK(cudaMalloc(&r->d_temp_scan, r->temp_scan_bytes));
+    CUDA_CHECK(cudaMalloc(&r->d_tileClassifyCounts, 2 * sizeof(unsigned int)));
 }
 
 void freeCylinderBinningResources(CylinderBinningResources* r) {
@@ -121,6 +125,7 @@ void freeCylinderBinningResources(CylinderBinningResources* r) {
     if (r->d_temp_sort64) cudaFree(r->d_temp_sort64);
     if (r->d_temp_rle) cudaFree(r->d_temp_rle);
     if (r->d_temp_scan) cudaFree(r->d_temp_scan);
+    cudaFree(r->d_tileClassifyCounts);
 }
 
 void resetCylinderBinningCounters(CylinderBinningResources* r, cudaStream_t stream) {
@@ -188,7 +193,9 @@ void executeCylinderPipelineBinning(
     if (numPairs > 0) {
         launchTiledCylinderRasterBinning(
             d_cylinders, r->d_tile_offsets, r->d_tile_entity_pairs_sorted,
-            d_depthBuffer, outputImage, r->tilesX, r->tilesY, stream);
+            d_depthBuffer, outputImage, r->tilesX, r->tilesY,
+            r->d_unique_out, r->d_counts_out, r->d_run_offsets,
+            r->d_tileClassifyCounts, stream);
     }
 }
 

--- a/kernels/hybrid_binning/cylinder_pipeline_binning.cu
+++ b/kernels/hybrid_binning/cylinder_pipeline_binning.cu
@@ -1,0 +1,212 @@
+/**
+ * @file cylinder_pipeline_binning.cu
+ * @brief Cylinder pipeline: Classify -> Generate pairs -> Sort -> RLE -> tileOffsets -> Small/Tiled raster.
+ */
+
+#include <cuda_runtime.h>
+#include <cstdio>
+#include <cub/cub.cuh>
+#include "cylinder_pipeline_binning.cuh"
+#include "hybrid_binning_types.h"
+#include "geometry/cylinder/cylinder.h"
+
+extern "C" void launchCylinderFrustumBBoxClassify(
+    const Cylinder* d_cylinders,
+    unsigned int* d_smallCylinderIndices,
+    unsigned int* d_smallCylinderCount,
+    CylinderBillboard* d_largeBillboards,
+    unsigned int* d_largeCylinderCount,
+    unsigned int* d_frustumPassedCount,
+    int cylinderCount,
+    cudaStream_t stream);
+extern "C" void launchGenerateCylinderPairs(
+    const CylinderBillboard* d_billboards,
+    unsigned int billboardCount,
+    unsigned int* d_keys,
+    unsigned int* d_values,
+    unsigned int* d_pairCount,
+    cudaStream_t stream);
+extern "C" void sortPairsAndBuildTileOffsets(
+    unsigned int* d_keys_in, unsigned int* d_values_in,
+    unsigned int* d_keys_out, unsigned int* d_values_out,
+    unsigned int num_pairs, unsigned int total_tiles,
+    unsigned int* d_tile_offsets,
+    unsigned int* d_unique_out, unsigned int* d_counts_out,
+    unsigned int* d_run_offsets, unsigned int* d_num_runs,
+    void* d_temp_sort, size_t temp_sort_bytes_sort,
+    void* d_temp_rle, size_t temp_rle_bytes,
+    void* d_temp_scan, size_t temp_scan_bytes,
+    cudaStream_t stream);
+extern "C" void buildTileOffsetsFromRLE(
+    const unsigned int* d_unique_out, const unsigned int* d_counts_out,
+    unsigned int num_runs, unsigned int num_pairs, unsigned int total_tiles,
+    unsigned int* d_run_offsets, unsigned int* d_tile_offsets,
+    void* d_temp_scan, size_t temp_scan_bytes, cudaStream_t stream);
+extern "C" void launchScatterAndFillTileOffsets(
+    const unsigned int* d_unique_out, const unsigned int* d_run_offsets,
+    unsigned int num_runs, unsigned int num_pairs, unsigned int total_tiles,
+    unsigned int* d_tile_offsets, cudaStream_t stream);
+extern "C" void launchSmallCylinderRaster(
+    const Cylinder* d_cylinders, const unsigned int* d_smallCylinderIndices,
+    unsigned int smallCylinderCount, unsigned int* d_depthBuffer,
+    cudaSurfaceObject_t outputImage, cudaStream_t stream);
+extern "C" void launchTiledCylinderRasterBinning(
+    const Cylinder* d_cylinders, const unsigned int* d_tile_offsets,
+    const unsigned int* d_sorted_entity_indices,
+    unsigned int* d_depthBuffer, cudaSurfaceObject_t outputImage,
+    unsigned int tilesX, unsigned int tilesY, cudaStream_t stream);
+
+#define CUDA_CHECK(call) do { cudaError_t e = call; if (e != cudaSuccess) printf("CUDA error %d: %s\n", e, cudaGetErrorString(e)); } while(0)
+
+void initCylinderBinningResources(CylinderBinningResources* r, int maxCylinders, int tilesX, int tilesY, int totalTiles) {
+    cudaGetLastError();
+    r->maxCylinders = maxCylinders;
+    r->tilesX = tilesX;
+    r->tilesY = tilesY;
+    r->totalTiles = totalTiles;
+    r->maxPairs = maxCylinders * 64;
+    if (r->maxPairs < totalTiles * 4) r->maxPairs = totalTiles * 4;
+
+    CUDA_CHECK(cudaMalloc(&r->d_smallIndices, maxCylinders * sizeof(unsigned int)));
+    CUDA_CHECK(cudaMalloc(&r->d_smallCount, sizeof(unsigned int)));
+    CUDA_CHECK(cudaMalloc(&r->d_largeCount, sizeof(unsigned int)));
+    CUDA_CHECK(cudaMalloc(&r->d_largeBillboards, maxCylinders * sizeof(CylinderBillboard)));
+    CUDA_CHECK(cudaMalloc(&r->d_frustumPassedCount, sizeof(unsigned int)));
+    CUDA_CHECK(cudaHostAlloc(&r->h_smallCount, sizeof(unsigned int), cudaHostAllocDefault));
+    CUDA_CHECK(cudaHostAlloc(&r->h_largeCount, sizeof(unsigned int), cudaHostAllocDefault));
+    CUDA_CHECK(cudaHostAlloc(&r->h_frustumPassedCount, sizeof(unsigned int), cudaHostAllocDefault));
+
+    CUDA_CHECK(cudaMalloc(&r->d_pairCount, sizeof(unsigned int)));
+    CUDA_CHECK(cudaMalloc(&r->d_keys_in, r->maxPairs * sizeof(unsigned int)));
+    CUDA_CHECK(cudaMalloc(&r->d_values_in, r->maxPairs * sizeof(unsigned int)));
+    CUDA_CHECK(cudaMalloc(&r->d_keys_out, r->maxPairs * sizeof(unsigned int)));
+    CUDA_CHECK(cudaMalloc(&r->d_values_out, r->maxPairs * sizeof(unsigned int)));
+    CUDA_CHECK(cudaMalloc(&r->d_tile_offsets, (totalTiles + 1) * sizeof(unsigned int)));
+    CUDA_CHECK(cudaMalloc(&r->d_unique_out, r->maxPairs * sizeof(unsigned int)));
+    CUDA_CHECK(cudaMalloc(&r->d_counts_out, r->maxPairs * sizeof(unsigned int)));
+    CUDA_CHECK(cudaMalloc(&r->d_run_offsets, r->maxPairs * sizeof(unsigned int)));
+    CUDA_CHECK(cudaMalloc(&r->d_num_runs, sizeof(unsigned int)));
+
+    r->d_temp_sort = nullptr;
+    r->d_temp_rle = nullptr;
+    r->d_temp_scan = nullptr;
+    r->temp_sort_bytes = 0;
+    r->temp_rle_bytes = 0;
+    r->temp_scan_bytes = 0;
+    sortPairsAndBuildTileOffsets(
+        r->d_keys_in, r->d_values_in, r->d_keys_out, r->d_values_out,
+        1, totalTiles, r->d_tile_offsets, r->d_unique_out, r->d_counts_out,
+        r->d_run_offsets, r->d_num_runs,
+        nullptr, r->temp_sort_bytes, nullptr, r->temp_rle_bytes,
+        nullptr, r->temp_scan_bytes, nullptr);
+    size_t scan_bytes = 0;
+    cub::DeviceScan::ExclusiveSum(nullptr, scan_bytes, (unsigned int*)nullptr, (unsigned int*)nullptr, (int)r->maxPairs);
+    if (scan_bytes > r->temp_scan_bytes) r->temp_scan_bytes = scan_bytes;
+    if (r->temp_sort_bytes > 0) CUDA_CHECK(cudaMalloc(&r->d_temp_sort, r->temp_sort_bytes));
+    if (r->temp_rle_bytes > 0) CUDA_CHECK(cudaMalloc(&r->d_temp_rle, r->temp_rle_bytes));
+    if (r->temp_scan_bytes > 0) CUDA_CHECK(cudaMalloc(&r->d_temp_scan, r->temp_scan_bytes));
+}
+
+void freeCylinderBinningResources(CylinderBinningResources* r) {
+    if (!r) return;
+    cudaFree(r->d_smallIndices);
+    cudaFree(r->d_smallCount);
+    cudaFree(r->d_largeCount);
+    cudaFree(r->d_largeBillboards);
+    cudaFree(r->d_frustumPassedCount);
+    cudaFreeHost(r->h_smallCount);
+    cudaFreeHost(r->h_largeCount);
+    cudaFreeHost(r->h_frustumPassedCount);
+    cudaFree(r->d_pairCount);
+    cudaFree(r->d_keys_in);
+    cudaFree(r->d_values_in);
+    cudaFree(r->d_keys_out);
+    cudaFree(r->d_values_out);
+    cudaFree(r->d_tile_offsets);
+    cudaFree(r->d_unique_out);
+    cudaFree(r->d_counts_out);
+    cudaFree(r->d_run_offsets);
+    cudaFree(r->d_num_runs);
+    if (r->d_temp_sort) cudaFree(r->d_temp_sort);
+    if (r->d_temp_rle) cudaFree(r->d_temp_rle);
+    if (r->d_temp_scan) cudaFree(r->d_temp_scan);
+}
+
+void resetCylinderBinningCounters(CylinderBinningResources* r, cudaStream_t stream) {
+    cudaMemsetAsync(r->d_smallCount, 0, sizeof(unsigned int), stream);
+    cudaMemsetAsync(r->d_largeCount, 0, sizeof(unsigned int), stream);
+    cudaMemsetAsync(r->d_frustumPassedCount, 0, sizeof(unsigned int), stream);
+}
+
+void executeCylinderPipelineBinning(
+    const Cylinder* d_cylinders,
+    int cylinderCount,
+    unsigned int* d_depthBuffer,
+    cudaSurfaceObject_t outputImage,
+    CylinderBinningResources* r,
+    cudaStream_t stream)
+{
+    if (cylinderCount == 0) return;
+
+    launchCylinderFrustumBBoxClassify(
+        d_cylinders, r->d_smallIndices, r->d_smallCount,
+        r->d_largeBillboards, r->d_largeCount, r->d_frustumPassedCount,
+        cylinderCount, stream);
+
+    cudaMemcpyAsync(r->h_smallCount, r->d_smallCount, sizeof(unsigned int), cudaMemcpyDeviceToHost, stream);
+    cudaMemcpyAsync(r->h_largeCount, r->d_largeCount, sizeof(unsigned int), cudaMemcpyDeviceToHost, stream);
+    cudaMemcpyAsync(r->h_frustumPassedCount, r->d_frustumPassedCount, sizeof(unsigned int), cudaMemcpyDeviceToHost, stream);
+    cudaStreamSynchronize(stream);
+
+    unsigned int smallCount = *r->h_smallCount;
+    unsigned int largeCount = *r->h_largeCount;
+
+    if (largeCount > 0) {
+        launchGenerateCylinderPairs(
+            r->d_largeBillboards, largeCount,
+            r->d_keys_in, r->d_values_in, r->d_pairCount, stream);
+        unsigned int numPairs;
+        cudaMemcpyAsync(&numPairs, r->d_pairCount, sizeof(unsigned int), cudaMemcpyDeviceToHost, stream);
+        cudaStreamSynchronize(stream);
+        if (numPairs > (unsigned int)r->maxPairs) numPairs = r->maxPairs;
+
+        sortPairsAndBuildTileOffsets(
+            r->d_keys_in, r->d_values_in, r->d_keys_out, r->d_values_out,
+            numPairs, r->totalTiles, r->d_tile_offsets,
+            r->d_unique_out, r->d_counts_out, r->d_run_offsets, r->d_num_runs,
+            r->d_temp_sort, r->temp_sort_bytes,
+            r->d_temp_rle, r->temp_rle_bytes,
+            r->d_temp_scan, r->temp_scan_bytes, stream);
+        unsigned int numRuns;
+        cudaMemcpyAsync(&numRuns, r->d_num_runs, sizeof(unsigned int), cudaMemcpyDeviceToHost, stream);
+        cudaStreamSynchronize(stream);
+
+        buildTileOffsetsFromRLE(
+            r->d_unique_out, r->d_counts_out, numRuns, numPairs, r->totalTiles,
+            r->d_run_offsets, r->d_tile_offsets,
+            r->d_temp_scan, r->temp_scan_bytes, stream);
+        launchScatterAndFillTileOffsets(
+            r->d_unique_out, r->d_run_offsets, numRuns, numPairs, r->totalTiles,
+            r->d_tile_offsets, stream);
+    } else {
+        cudaMemsetAsync(r->d_tile_offsets, 0, (r->totalTiles + 1) * sizeof(unsigned int), stream);
+    }
+
+    if (smallCount > 0) {
+        launchSmallCylinderRaster(d_cylinders, r->d_smallIndices, smallCount, d_depthBuffer, outputImage, stream);
+    }
+
+    if (largeCount > 0) {
+        launchTiledCylinderRasterBinning(
+            d_cylinders, r->d_tile_offsets, r->d_values_out,
+            d_depthBuffer, outputImage, r->tilesX, r->tilesY, stream);
+    }
+}
+
+void getCylinderBinningStats(CylinderBinningResources* r,
+    unsigned int* outFrustumPassed, unsigned int* outSmallCount, unsigned int* outLargeCount)
+{
+    if (outFrustumPassed) *outFrustumPassed = *r->h_frustumPassedCount;
+    if (outSmallCount) *outSmallCount = *r->h_smallCount;
+    if (outLargeCount) *outLargeCount = *r->h_largeCount;
+}

--- a/kernels/hybrid_binning/cylinder_pipeline_binning.cuh
+++ b/kernels/hybrid_binning/cylinder_pipeline_binning.cuh
@@ -15,23 +15,21 @@ struct CylinderBinningResources {
     unsigned int* d_smallIndices;
     unsigned int* d_smallCount;
     unsigned int* d_largeCount;
-    CylinderBillboard* d_largeBillboards;
     unsigned int* d_frustumPassedCount;
     unsigned int* h_smallCount;
-    unsigned int* h_largeCount;
+    unsigned int* h_pairCount;
     unsigned int* h_frustumPassedCount;
+    unsigned long long* d_tile_entity_pairs;
+    unsigned long long* d_tile_entity_pairs_sorted;
     unsigned int* d_pairCount;
-    unsigned int* d_keys_in;
-    unsigned int* d_values_in;
-    unsigned int* d_keys_out;
-    unsigned int* d_values_out;
+    unsigned int* d_keys_extract;
     unsigned int* d_tile_offsets;
     unsigned int* d_unique_out;
     unsigned int* d_counts_out;
     unsigned int* d_run_offsets;
     unsigned int* d_num_runs;
-    void* d_temp_sort;
-    size_t temp_sort_bytes;
+    void* d_temp_sort64;
+    size_t temp_sort64_bytes;
     void* d_temp_rle;
     size_t temp_rle_bytes;
     void* d_temp_scan;
@@ -43,7 +41,7 @@ struct CylinderBinningResources {
     int totalTiles;
 };
 
-void initCylinderBinningResources(CylinderBinningResources* r, int maxCylinders, int tilesX, int tilesY, int totalTiles);
+void initCylinderBinningResources(CylinderBinningResources* r, int maxCylinders, int tilesX, int tilesY, int totalTiles, int avgEntitiesPerTile = 0);
 void freeCylinderBinningResources(CylinderBinningResources* r);
 void resetCylinderBinningCounters(CylinderBinningResources* r, cudaStream_t stream);
 

--- a/kernels/hybrid_binning/cylinder_pipeline_binning.cuh
+++ b/kernels/hybrid_binning/cylinder_pipeline_binning.cuh
@@ -38,6 +38,7 @@ struct CylinderBinningResources {
     int tilesX;
     int tilesY;
     int totalTiles;
+    unsigned int* d_tileClassifyCounts; // [0]=lightCount, [1]=heavyCount
 };
 
 void initCylinderBinningResources(CylinderBinningResources* r, int maxCylinders, int tilesX, int tilesY, int totalTiles, int avgEntitiesPerTile = 0);

--- a/kernels/hybrid_binning/cylinder_pipeline_binning.cuh
+++ b/kernels/hybrid_binning/cylinder_pipeline_binning.cuh
@@ -38,7 +38,13 @@ struct CylinderBinningResources {
     int tilesX;
     int tilesY;
     int totalTiles;
-    unsigned int* d_tileClassifyCounts; // [0]=lightCount, [1]=heavyCount
+    // Work-group expansion buffers
+    unsigned int* d_wg_tileId;       ///< tile index for each work group
+    unsigned int* d_wg_entityStart;  ///< start offset in sorted pairs for each WG
+    unsigned int* d_wg_entityCount;  ///< entity count per WG (<= SHARED_BATCH_SIZE)
+    unsigned int* d_wg_totalCount;   ///< single uint: atomicAdd counter for total WGs
+    unsigned int* h_wg_totalCount;   ///< pinned host copy of total WG count
+    int maxWorkGroups;               ///< allocated size of WG arrays
 };
 
 void initCylinderBinningResources(CylinderBinningResources* r, int maxCylinders, int tilesX, int tilesY, int totalTiles, int avgEntitiesPerTile = 0);

--- a/kernels/hybrid_binning/cylinder_pipeline_binning.cuh
+++ b/kernels/hybrid_binning/cylinder_pipeline_binning.cuh
@@ -22,7 +22,6 @@ struct CylinderBinningResources {
     unsigned long long* d_tile_entity_pairs;
     unsigned long long* d_tile_entity_pairs_sorted;
     unsigned int* d_pairCount;
-    unsigned int* d_keys_extract;
     unsigned int* d_tile_offsets;
     unsigned int* d_unique_out;
     unsigned int* d_counts_out;

--- a/kernels/hybrid_binning/cylinder_pipeline_binning.cuh
+++ b/kernels/hybrid_binning/cylinder_pipeline_binning.cuh
@@ -1,0 +1,61 @@
+/**
+ * @file cylinder_pipeline_binning.cuh
+ * @brief Cylinder pipeline for binning-by-sort.
+ */
+
+#ifndef CYLINDER_PIPELINE_BINNING_CUH
+#define CYLINDER_PIPELINE_BINNING_CUH
+
+#include <cuda_runtime.h>
+#include <glm/glm.hpp>
+#include "hybrid_binning_types.h"
+#include "geometry/cylinder/cylinder.h"
+
+struct CylinderBinningResources {
+    unsigned int* d_smallIndices;
+    unsigned int* d_smallCount;
+    unsigned int* d_largeCount;
+    CylinderBillboard* d_largeBillboards;
+    unsigned int* d_frustumPassedCount;
+    unsigned int* h_smallCount;
+    unsigned int* h_largeCount;
+    unsigned int* h_frustumPassedCount;
+    unsigned int* d_pairCount;
+    unsigned int* d_keys_in;
+    unsigned int* d_values_in;
+    unsigned int* d_keys_out;
+    unsigned int* d_values_out;
+    unsigned int* d_tile_offsets;
+    unsigned int* d_unique_out;
+    unsigned int* d_counts_out;
+    unsigned int* d_run_offsets;
+    unsigned int* d_num_runs;
+    void* d_temp_sort;
+    size_t temp_sort_bytes;
+    void* d_temp_rle;
+    size_t temp_rle_bytes;
+    void* d_temp_scan;
+    size_t temp_scan_bytes;
+    int maxCylinders;
+    int maxPairs;
+    int tilesX;
+    int tilesY;
+    int totalTiles;
+};
+
+void initCylinderBinningResources(CylinderBinningResources* r, int maxCylinders, int tilesX, int tilesY, int totalTiles);
+void freeCylinderBinningResources(CylinderBinningResources* r);
+void resetCylinderBinningCounters(CylinderBinningResources* r, cudaStream_t stream);
+
+void executeCylinderPipelineBinning(
+    const Cylinder* d_cylinders,
+    int cylinderCount,
+    unsigned int* d_depthBuffer,
+    cudaSurfaceObject_t outputImage,
+    CylinderBinningResources* r,
+    cudaStream_t stream);
+
+void getCylinderBinningStats(CylinderBinningResources* r,
+    unsigned int* outFrustumPassed, unsigned int* outSmallCount, unsigned int* outLargeCount);
+
+#endif

--- a/kernels/hybrid_binning/frustum_bbox_classify.cu
+++ b/kernels/hybrid_binning/frustum_bbox_classify.cu
@@ -204,15 +204,18 @@ __global__ void sphereFrustumBBoxClassifyKernel(
     float area = width * height;
     if (area < 1.0f) return;
     
-    if (area <= (float)hybridCst.smallEntityThreshold) {
+    if (area <= (float)hybridCst.smallEntityThreshold) 
+    {
         unsigned int outIdx = atomicAdd(smallSphereCount, 1u);
         if (outIdx < (unsigned int)hybridCst.sphereCount)
             smallSphereIndices[outIdx] = idx;
-    } else {
+    } 
+    else 
+    {
         int tileMinX = (int)(screenMin.x / TILE_SIZE);
         int tileMinY = (int)(screenMin.y / TILE_SIZE);
         int tileMaxX = (int)(screenMax.x / TILE_SIZE);
-        int tileMaxY = (int)(screenMax.y / TILE_SIZE);
+        int tileMaxY = (int)(screenMax.y / TILE_SIZE)+1;
         if (tileMinX < 0) tileMinX = 0;
         if (tileMinY < 0) tileMinY = 0;
         if (tileMaxX >= hybridCst.tilesX) tileMaxX = hybridCst.tilesX - 1;

--- a/kernels/hybrid_binning/frustum_bbox_classify.cu
+++ b/kernels/hybrid_binning/frustum_bbox_classify.cu
@@ -128,13 +128,13 @@ __device__ inline void computeCylinderBBox(
     glm::vec3 camImpPosA, camImpPosB;
     if ( camA.z < camB.z )
 	{
-		camImpPosA = camB;
-		camImpPosB = camA;
+		camImpPosA = glm::vec3(camB);
+		camImpPosB = glm::vec3(camA);
 	}
 	else
 	{
-		camImpPosA = camA;
-		camImpPosB = camB;
+		camImpPosA = glm::vec3(camA);
+		camImpPosB = glm::vec3(camB);
 	}
     glm::vec3 center = normalize( ( camImpPosA + camImpPosB ) * 0.5f );
     // Cylinder axis
@@ -151,7 +151,7 @@ __device__ inline void computeCylinderBBox(
     const float sinAngle = __fdividef(radius, dV0);
     float		angle	 = asinf( sinAngle );
     const glm::vec3	y1		 = y * radius;
-    const glm::vec3	x2		 = x * radius * cosf( angle );
+    const glm::vec3	x2		 = x * radius * __cosf( angle );
     const glm::vec3	y2		 = y1 * sinAngle;
     angle				 = asinf( __fdividef(radius, dV1) );
     const glm::vec3 x3		 = x * ( dV1 - radius ) * __tanf( angle );
@@ -270,17 +270,13 @@ __global__ void cylinderFrustumBBoxClassifyKernel(
     float screenMinX = 1e6f, screenMinY = 1e6f, screenMaxX = -1e6f, screenMaxY = -1e6f;
     for (int i = 0; i < 4; i++) 
     {
-        float sx = fmaf(projectedPoints[i].x, 0.5f, 0.5f) * (float)hybridCst.screenWidth;
-        float sy = fmaf(projectedPoints[i].y, 0.5f, 0.5f) * (float)hybridCst.screenHeight;
-        if (sx < screenMinX) screenMinX = sx;
-        if (sy < screenMinY) screenMinY = sy;
-        if (sx > screenMaxX) screenMaxX = sx;
-        if (sy > screenMaxY) screenMaxY = sy;
+        projectedPoints[i].x = fmaf(projectedPoints[i].x, 0.5f, 0.5f) * (float)hybridCst.screenWidth;
+        projectedPoints[i].y = fmaf(projectedPoints[i].y, 0.5f, 0.5f) * (float)hybridCst.screenHeight;
+        if (projectedPoints[i].x < screenMinX) screenMinX = projectedPoints[i].x;
+        if (projectedPoints[i].y < screenMinY) screenMinY = projectedPoints[i].y;
+        if (projectedPoints[i].x > screenMaxX) screenMaxX = projectedPoints[i].x;
+        if (projectedPoints[i].y > screenMaxY) screenMaxY = projectedPoints[i].y;
     }
-    screenMinX = fmaxf(0.0f, screenMinX);
-    screenMinY = fmaxf(0.0f, screenMinY);
-    screenMaxX = fminf((float)hybridCst.screenWidth, screenMaxX);
-    screenMaxY = fminf((float)hybridCst.screenHeight, screenMaxY);
     
     float area = quadArea(projectedPoints[0], projectedPoints[1], projectedPoints[2], projectedPoints[3]);
     if (area < 1.0f) return;
@@ -289,7 +285,13 @@ __global__ void cylinderFrustumBBoxClassifyKernel(
         unsigned int outIdx = atomicAdd(smallCylinderCount, 1u);
         if (outIdx < (unsigned int)hybridCst.cylinderCount)
             smallCylinderIndices[outIdx] = idx;
-    } else {
+        } 
+    else 
+    {
+        screenMinX = fmaxf(0.0f, screenMinX);
+        screenMinY = fmaxf(0.0f, screenMinY);
+        screenMaxX = fminf((float)hybridCst.screenWidth, screenMaxX);
+        screenMaxY = fminf((float)hybridCst.screenHeight, screenMaxY);
         int tileMinX = (int)(screenMinX / TILE_SIZE);
         int tileMinY = (int)(screenMinY / TILE_SIZE);
         int tileMaxX = (int)(screenMaxX / TILE_SIZE);

--- a/kernels/hybrid_binning/frustum_bbox_classify.cu
+++ b/kernels/hybrid_binning/frustum_bbox_classify.cu
@@ -17,7 +17,7 @@ __device__ inline bool isOnOrForwardOfPlane(const glm::vec4& plane, const glm::v
     return d >= -spherePosR.w;
 }
 
-__device__ inline bool isOnOrForwardPlaneAABB(glm::vec4 plane, BBox3D& bbox) 
+__device__ inline bool isOnOrForwardPlaneAABB(glm::vec4 plane, _BBox3D& bbox) 
 {
     glm::vec3 negativeVertex = bbox.mMin;
     glm::vec3 normal = glm::vec3(plane.x, plane.y, plane.z);
@@ -53,13 +53,13 @@ __device__ inline bool isCylinderInsideFrustum(const glm::vec3 pa,
     glm::vec3 pb_sub_e = pb - e;
     glm::vec3 pa_add_e = pa + e;
     glm::vec3 pb_add_e = pb + e;
-    BBox3D bbox3d = BBox3D{glm::vec3(fminf(pa_sub_e.x, pb_sub_e.x), fminf(pa_sub_e.y, pb_sub_e.y), fminf(pa_sub_e.z, pb_sub_e.z)), glm::vec3(fmaxf(pa_add_e.x, pb_add_e.x), fmaxf(pa_add_e.y, pb_add_e.y), fmaxf(pa_add_e.z, pb_add_e.z))};
-    return isOnOrForwardPlaneAABB(cst.frustumPlanes[0], bbox3d) &&
-    isOnOrForwardPlaneAABB(cst.frustumPlanes[1], bbox3d) &&
-    isOnOrForwardPlaneAABB(cst.frustumPlanes[2], bbox3d) &&
-    isOnOrForwardPlaneAABB(cst.frustumPlanes[3], bbox3d) &&
-    isOnOrForwardPlaneAABB(cst.frustumPlanes[4], bbox3d) &&
-    isOnOrForwardPlaneAABB(cst.frustumPlanes[5], bbox3d);
+    _BBox3D bbox3d = _BBox3D{glm::vec3(fminf(pa_sub_e.x, pb_sub_e.x), fminf(pa_sub_e.y, pb_sub_e.y), fminf(pa_sub_e.z, pb_sub_e.z)), glm::vec3(fmaxf(pa_add_e.x, pb_add_e.x), fmaxf(pa_add_e.y, pb_add_e.y), fmaxf(pa_add_e.z, pb_add_e.z))};
+    return isOnOrForwardPlaneAABB(hybridCst.frustumPlanes[0], bbox3d) &&
+    isOnOrForwardPlaneAABB(hybridCst.frustumPlanes[1], bbox3d) &&
+    isOnOrForwardPlaneAABB(hybridCst.frustumPlanes[2], bbox3d) &&
+    isOnOrForwardPlaneAABB(hybridCst.frustumPlanes[3], bbox3d) &&
+    isOnOrForwardPlaneAABB(hybridCst.frustumPlanes[4], bbox3d) &&
+    isOnOrForwardPlaneAABB(hybridCst.frustumPlanes[5], bbox3d);
 }
 
 __device__ inline void computeSphereBBox(
@@ -120,7 +120,7 @@ __device__ inline void computeCylinderBBox(
     const glm::vec3& pa,
     const glm::vec3& pb,
     float radius,
-    glm::vec2& projectedPoints[4])
+    glm::vec2 projectedPoints[4])
 {
     glm::vec4 camA = hybridCst.view * glm::vec4(pa, 1.0f);
     glm::vec4 camB = hybridCst.view * glm::vec4(pb, 1.0f);
@@ -162,10 +162,10 @@ __device__ inline void computeCylinderBBox(
     const glm::vec3 v3 = camImpPosB - x3 + y1;
     const glm::vec3 v4 = camImpPosB + x3 + y1;
 
-    const glm::vec4 v1Proj = cst.proj * glm::vec4(v1, 1.0f);
-    const glm::vec4 v2Proj = cst.proj * glm::vec4(v2, 1.0f);
-    const glm::vec4 v3Proj = cst.proj * glm::vec4(v3, 1.0f);
-    const glm::vec4 v4Proj = cst.proj * glm::vec4(v4, 1.0f);
+    const glm::vec4 v1Proj = hybridCst.proj * glm::vec4(v1, 1.0f);
+    const glm::vec4 v2Proj = hybridCst.proj * glm::vec4(v2, 1.0f);
+    const glm::vec4 v3Proj = hybridCst.proj * glm::vec4(v3, 1.0f);
+    const glm::vec4 v4Proj = hybridCst.proj * glm::vec4(v4, 1.0f);
 
     glm::vec3 ndcv1Proj = glm::vec3(__fdividef(v1Proj.x, v1Proj.w), __fdividef(v1Proj.y, v1Proj.w), __fdividef(v1Proj.z, v1Proj.w));
     glm::vec3 ndcv2Proj = glm::vec3(__fdividef(v2Proj.x, v2Proj.w), __fdividef(v2Proj.y, v2Proj.w), __fdividef(v2Proj.z, v2Proj.w));
@@ -182,9 +182,10 @@ __global__ void sphereFrustumBBoxClassifyKernel(
     const glm::vec4* __restrict__ spheres,
     unsigned int* __restrict__ smallSphereIndices,
     unsigned int* __restrict__ smallSphereCount,
-    TileSphereIDPairs* __restrict__ largeSphereTilePairs,
-    unsigned int* __restrict__ largeSphereCount,
-    unsigned int* __restrict__ frustumPassedCount)
+    unsigned long long* __restrict__ d_tile_entity_pairs,
+    unsigned int* __restrict__ d_pair_count,
+    unsigned int* __restrict__ frustumPassedCount,
+    int maxPairs)
 {
     const unsigned int idx = blockIdx.x * blockDim.x + threadIdx.x;
     if (idx >= hybridCst.sphereCount) return;
@@ -205,10 +206,26 @@ __global__ void sphereFrustumBBoxClassifyKernel(
     
     if (area <= (float)hybridCst.smallEntityThreshold) {
         unsigned int outIdx = atomicAdd(smallSphereCount, 1u);
-        smallSphereIndices[outIdx] = idx;
+        if (outIdx < (unsigned int)hybridCst.sphereCount)
+            smallSphereIndices[outIdx] = idx;
     } else {
-        atomicAdd(largeSphereCount, 1u);
-        addTileSphereIDPair(largeSphereTilePairs, idx, screenMin, screenMax);
+        int tileMinX = (int)(screenMin.x / TILE_SIZE);
+        int tileMinY = (int)(screenMin.y / TILE_SIZE);
+        int tileMaxX = (int)(screenMax.x / TILE_SIZE);
+        int tileMaxY = (int)(screenMax.y / TILE_SIZE);
+        if (tileMinX < 0) tileMinX = 0;
+        if (tileMinY < 0) tileMinY = 0;
+        if (tileMaxX >= hybridCst.tilesX) tileMaxX = hybridCst.tilesX - 1;
+        if (tileMaxY >= hybridCst.tilesY) tileMaxY = hybridCst.tilesY - 1;
+        for (int ty = tileMinY; ty <= tileMaxY; ++ty) {
+            for (int tx = tileMinX; tx <= tileMaxX; ++tx) {
+                unsigned int tileId = (unsigned int)(ty * hybridCst.tilesX + tx);
+                unsigned long long pair = ((unsigned long long)tileId << 32) | (unsigned long long)idx;
+                unsigned int outIdx = atomicAdd(d_pair_count, 1u);
+                if (outIdx < (unsigned int)maxPairs)
+                    d_tile_entity_pairs[outIdx] = pair;
+            }
+        }
     }
 }
 
@@ -227,9 +244,10 @@ __global__ void cylinderFrustumBBoxClassifyKernel(
     const Cylinder* __restrict__ cylinders,
     unsigned int* __restrict__ smallCylinderIndices,
     unsigned int* __restrict__ smallCylinderCount,
-    TileCylinderIDPairs* __restrict__ largeCylinderTilePairs,
-    unsigned int* __restrict__ largeCylinderCount,
-    unsigned int* __restrict__ frustumPassedCount)
+    unsigned long long* __restrict__ d_tile_entity_pairs,
+    unsigned int* __restrict__ d_pair_count,
+    unsigned int* __restrict__ frustumPassedCount,
+    int maxPairs)
 {
     const unsigned int idx = blockIdx.x * blockDim.x + threadIdx.x;
     if (idx >= hybridCst.cylinderCount) return;
@@ -245,23 +263,47 @@ __global__ void cylinderFrustumBBoxClassifyKernel(
     glm::vec2 projectedPoints[4];
     computeCylinderBBox(pa, pb, radius, projectedPoints);
 
-    // Convert NDC to screen coordinates
+    // Convert NDC to screen coordinates and compute screen bbox
+    float screenMinX = 1e6f, screenMinY = 1e6f, screenMaxX = -1e6f, screenMaxY = -1e6f;
     for (int i = 0; i < 4; i++) 
     {
-        projectedPoints[i].x = (projectedPoints[i].x * 0.5f + 0.5f) * (float)hybridCst.screenWidth;
-        projectedPoints[i].y = (projectedPoints[i].y * 0.5f + 0.5f) * (float)hybridCst.screenHeight;
-        projectedPoints[i] = glm::clamp(projectedPoints[i], glm::vec2(0.0f), glm::vec2((float)hybridCst.screenWidth, (float)hybridCst.screenHeight));
+        float sx = fmaf(projectedPoints[i].x, 0.5f, 0.5f) * (float)hybridCst.screenWidth;
+        float sy = fmaf(projectedPoints[i].y, 0.5f, 0.5f) * (float)hybridCst.screenHeight;
+        if (sx < screenMinX) screenMinX = sx;
+        if (sy < screenMinY) screenMinY = sy;
+        if (sx > screenMaxX) screenMaxX = sx;
+        if (sy > screenMaxY) screenMaxY = sy;
     }
+    screenMinX = fmaxf(0.0f, screenMinX);
+    screenMinY = fmaxf(0.0f, screenMinY);
+    screenMaxX = fminf((float)hybridCst.screenWidth, screenMaxX);
+    screenMaxY = fminf((float)hybridCst.screenHeight, screenMaxY);
     
     float area = quadArea(projectedPoints[0], projectedPoints[1], projectedPoints[2], projectedPoints[3]);
     if (area < 1.0f) return;
     
     if (area <= (float)hybridCst.smallEntityThreshold) {
         unsigned int outIdx = atomicAdd(smallCylinderCount, 1u);
-        smallCylinderIndices[outIdx] = idx;
+        if (outIdx < (unsigned int)hybridCst.cylinderCount)
+            smallCylinderIndices[outIdx] = idx;
     } else {
-        atomicAdd(largeCylinderCount, 1u);
-        addTileSphereIDPair(largeCylinderTilePairs, idx, screenMin, screenMax);
+        int tileMinX = (int)(screenMinX / TILE_SIZE);
+        int tileMinY = (int)(screenMinY / TILE_SIZE);
+        int tileMaxX = (int)(screenMaxX / TILE_SIZE);
+        int tileMaxY = (int)(screenMaxY / TILE_SIZE);
+        if (tileMinX < 0) tileMinX = 0;
+        if (tileMinY < 0) tileMinY = 0;
+        if (tileMaxX >= hybridCst.tilesX) tileMaxX = hybridCst.tilesX - 1;
+        if (tileMaxY >= hybridCst.tilesY) tileMaxY = hybridCst.tilesY - 1;
+        for (int ty = tileMinY; ty <= tileMaxY; ++ty) {
+            for (int tx = tileMinX; tx <= tileMaxX; ++tx) {
+                unsigned int tileId = (unsigned int)(ty * hybridCst.tilesX + tx);
+                unsigned long long pair = ((unsigned long long)tileId << 32) | (unsigned long long)idx;
+                unsigned int outIdx = atomicAdd(d_pair_count, 1u);
+                if (outIdx < (unsigned int)maxPairs)
+                    d_tile_entity_pairs[outIdx] = pair;
+            }
+        }
     }
 }
 
@@ -273,32 +315,34 @@ extern "C" void launchSphereFrustumBBoxClassify(
     const glm::vec4* d_spheres,
     unsigned int* d_smallSphereIndices,
     unsigned int* d_smallSphereCount,
-    SphereBillboard* d_largeBillboards,
-    unsigned int* d_largeSphereCount,
+    unsigned long long* d_tile_entity_pairs,
+    unsigned int* d_pair_count,
     unsigned int* d_frustumPassedCount,
     int sphereCount,
+    int maxPairs,
     cudaStream_t stream)
 {
     dim3 block(CULL_BLOCK_SIZE);
     dim3 grid((sphereCount + block.x - 1) / block.x);
     sphereFrustumBBoxClassifyKernel<<<grid, block, 0, stream>>>(
         d_spheres, d_smallSphereIndices, d_smallSphereCount,
-        d_largeBillboards, d_largeSphereCount, d_frustumPassedCount);
+        d_tile_entity_pairs, d_pair_count, d_frustumPassedCount, maxPairs);
 }
 
 extern "C" void launchCylinderFrustumBBoxClassify(
     const Cylinder* d_cylinders,
     unsigned int* d_smallCylinderIndices,
     unsigned int* d_smallCylinderCount,
-    CylinderBillboard* d_largeBillboards,
-    unsigned int* d_largeCylinderCount,
+    unsigned long long* d_tile_entity_pairs,
+    unsigned int* d_pair_count,
     unsigned int* d_frustumPassedCount,
     int cylinderCount,
+    int maxPairs,
     cudaStream_t stream)
 {
     dim3 block(CULL_BLOCK_SIZE);
     dim3 grid((cylinderCount + block.x - 1) / block.x);
     cylinderFrustumBBoxClassifyKernel<<<grid, block, 0, stream>>>(
         d_cylinders, d_smallCylinderIndices, d_smallCylinderCount,
-        d_largeBillboards, d_largeCylinderCount, d_frustumPassedCount);
+        d_tile_entity_pairs, d_pair_count, d_frustumPassedCount, maxPairs);
 }

--- a/kernels/hybrid_binning/frustum_bbox_classify.cu
+++ b/kernels/hybrid_binning/frustum_bbox_classify.cu
@@ -1,0 +1,304 @@
+/**
+ * @file frustum_bbox_classify.cu
+ * @brief Frustum culling + BBox + Size classification (same as hybrid, for binning pipeline).
+ */
+
+#include <cuda_runtime.h>
+#include <device_launch_parameters.h>
+#include <glm/glm.hpp>
+
+#include "hybrid_binning_types.h"
+#include "geometry/cylinder/cylinder.h"
+
+__constant__ HybridConstants hybridCst;
+
+__device__ inline bool isOnOrForwardOfPlane(const glm::vec4& plane, const glm::vec4& spherePosR) {
+    float d = glm::dot(glm::vec3(plane), glm::vec3(spherePosR)) - plane.w;
+    return d >= -spherePosR.w;
+}
+
+__device__ inline bool isOnOrForwardPlaneAABB(glm::vec4 plane, BBox3D& bbox) 
+{
+    glm::vec3 negativeVertex = bbox.mMin;
+    glm::vec3 normal = glm::vec3(plane.x, plane.y, plane.z);
+    float distance = plane.w;
+
+    if (normal.x >= 0) negativeVertex.x = bbox.mMax.x;
+        else negativeVertex.x = bbox.mMin.x;
+
+    if (normal.y >= 0) negativeVertex.y = bbox.mMax.y;
+        else negativeVertex.y = bbox.mMin.y;
+
+    if (normal.z >= 0) negativeVertex.z = bbox.mMax.z;
+        else negativeVertex.z = bbox.mMin.z;
+
+    return glm::dot(normal, negativeVertex) - distance >= 0;
+}
+
+__device__ inline bool isSphereInsideFrustum(const glm::vec4& spherePosR) {
+    #pragma unroll
+    for (int i = 0; i < 6; ++i) {
+        if (!isOnOrForwardOfPlane(hybridCst.frustumPlanes[i], spherePosR))
+            return false;
+    }
+    return true;
+}
+
+__device__ inline bool isCylinderInsideFrustum(const glm::vec3 pa,
+    const glm::vec3 pb, float radius)
+{
+    glm::vec3 a = pb - pa;
+    glm::vec3 e = radius*sqrt( 1.0f - a*a/glm::dot(a,a) );
+    glm::vec3 pa_sub_e = pa - e;
+    glm::vec3 pb_sub_e = pb - e;
+    glm::vec3 pa_add_e = pa + e;
+    glm::vec3 pb_add_e = pb + e;
+    BBox3D bbox3d = BBox3D{glm::vec3(fminf(pa_sub_e.x, pb_sub_e.x), fminf(pa_sub_e.y, pb_sub_e.y), fminf(pa_sub_e.z, pb_sub_e.z)), glm::vec3(fmaxf(pa_add_e.x, pb_add_e.x), fmaxf(pa_add_e.y, pb_add_e.y), fmaxf(pa_add_e.z, pb_add_e.z))};
+    return isOnOrForwardPlaneAABB(cst.frustumPlanes[0], bbox3d) &&
+    isOnOrForwardPlaneAABB(cst.frustumPlanes[1], bbox3d) &&
+    isOnOrForwardPlaneAABB(cst.frustumPlanes[2], bbox3d) &&
+    isOnOrForwardPlaneAABB(cst.frustumPlanes[3], bbox3d) &&
+    isOnOrForwardPlaneAABB(cst.frustumPlanes[4], bbox3d) &&
+    isOnOrForwardPlaneAABB(cst.frustumPlanes[5], bbox3d);
+}
+
+__device__ inline void computeSphereBBox(
+    const glm::vec4& spherePosR,
+    glm::vec2& screenMin,
+    glm::vec2& screenMax,
+    float& centerDepth)
+{
+    glm::vec4 camSpace4 = hybridCst.view * glm::vec4(glm::vec3(spherePosR), 1.0f);
+    glm::vec3 cameraSpaceSphere = glm::vec3(camSpace4);
+    glm::vec3 normCamSpaceSphere = glm::normalize(cameraSpaceSphere);
+    glm::vec3 camImposPos = cameraSpaceSphere - normCamSpaceSphere * spherePosR.w;
+    
+    float dist = glm::length(cameraSpaceSphere) + 1e-6f;
+    float sinAngle = spherePosR.w / dist;
+    float tanAngle = tanf(asinf(fminf(sinAngle, 0.999f)));
+    float quadScale = tanAngle * glm::length(camImposPos);
+    
+    glm::vec3 upVec = glm::vec3(0.0f, 1.0f, 0.0f);
+    glm::vec3 impU = glm::normalize(glm::cross(normCamSpaceSphere, upVec));
+    if (glm::length(impU) < 0.001f) impU = glm::vec3(1.0f, 0.0f, 0.0f);
+    glm::vec3 impV = glm::cross(impU, normCamSpaceSphere) * quadScale;
+    impU *= quadScale;
+    
+    glm::vec3 corners[4] = {
+        camImposPos + impU + impV,
+        camImposPos - impU + impV,
+        camImposPos + impU - impV,
+        camImposPos - impU - impV
+    };
+    
+    glm::vec2 minC(1e6f), maxC(-1e6f);
+    #pragma unroll
+    for (int i = 0; i < 4; ++i) {
+        glm::vec4 clip = hybridCst.proj * glm::vec4(corners[i], 1.0f);
+        float iw = 1.0f / clip.w;
+        minC.x = fminf(minC.x, clip.x * iw);
+        minC.y = fminf(minC.y, clip.y * iw);
+        maxC.x = fmaxf(maxC.x, clip.x * iw);
+        maxC.y = fmaxf(maxC.y, clip.y * iw);
+    }
+    
+    screenMin.x = floorf((minC.x * 0.5f + 0.5f) * hybridCst.screenWidth);
+    screenMin.y = floorf((minC.y * 0.5f + 0.5f) * hybridCst.screenHeight);
+    screenMax.x = ceilf((maxC.x * 0.5f + 0.5f) * hybridCst.screenWidth);
+    screenMax.y = ceilf((maxC.y * 0.5f + 0.5f) * hybridCst.screenHeight);
+    
+    screenMin.x = fmaxf(0.0f, screenMin.x);
+    screenMin.y = fmaxf(0.0f, screenMin.y);
+    screenMax.x = fminf((float)hybridCst.screenWidth, screenMax.x);
+    screenMax.y = fminf((float)hybridCst.screenHeight, screenMax.y);
+    
+    glm::vec4 centerClip = hybridCst.proj * glm::vec4(cameraSpaceSphere, 1.0f);
+    centerDepth = centerClip.z / centerClip.w;
+}
+
+__device__ inline void computeCylinderBBox(
+    const glm::vec3& pa,
+    const glm::vec3& pb,
+    float radius,
+    glm::vec2& projectedPoints[4])
+{
+    glm::vec4 camA = hybridCst.view * glm::vec4(pa, 1.0f);
+    glm::vec4 camB = hybridCst.view * glm::vec4(pb, 1.0f);
+    
+    glm::vec3 camImpPosA, camImpPosB;
+    if ( camA.z < camB.z )
+	{
+		camImpPosA = camB;
+		camImpPosB = camA;
+	}
+	else
+	{
+		camImpPosA = camA;
+		camImpPosB = camB;
+	}
+    glm::vec3 center = normalize( ( camImpPosA + camImpPosB ) * 0.5f );
+    // Cylinder axis
+    const glm::vec3 z = normalize(camImpPosB - camImpPosA);
+
+    // Find orthonormal x,y axes orthogonal to cylinder axis
+    glm::vec3 x = normalize(cross(center, z));
+    glm::vec3 y = normalize(cross(x, z)); // make full basis
+
+    // Compute impostor construction vectors.
+    const float dV0 = length( camImpPosA );
+    const float dV1 = length( camImpPosB );
+
+    const float sinAngle = __fdividef(radius, dV0);
+    float		angle	 = asinf( sinAngle );
+    const glm::vec3	y1		 = y * radius;
+    const glm::vec3	x2		 = x * radius * cosf( angle );
+    const glm::vec3	y2		 = y1 * sinAngle;
+    angle				 = asinf( __fdividef(radius, dV1) );
+    const glm::vec3 x3		 = x * ( dV1 - radius ) * __tanf( angle );
+
+    // Compute impostors vertices.
+    const glm::vec3 v1 = camImpPosA - x2 + y2;
+    const glm::vec3 v2 = camImpPosA + x2 + y2;
+    const glm::vec3 v3 = camImpPosB - x3 + y1;
+    const glm::vec3 v4 = camImpPosB + x3 + y1;
+
+    const glm::vec4 v1Proj = cst.proj * glm::vec4(v1, 1.0f);
+    const glm::vec4 v2Proj = cst.proj * glm::vec4(v2, 1.0f);
+    const glm::vec4 v3Proj = cst.proj * glm::vec4(v3, 1.0f);
+    const glm::vec4 v4Proj = cst.proj * glm::vec4(v4, 1.0f);
+
+    glm::vec3 ndcv1Proj = glm::vec3(__fdividef(v1Proj.x, v1Proj.w), __fdividef(v1Proj.y, v1Proj.w), __fdividef(v1Proj.z, v1Proj.w));
+    glm::vec3 ndcv2Proj = glm::vec3(__fdividef(v2Proj.x, v2Proj.w), __fdividef(v2Proj.y, v2Proj.w), __fdividef(v2Proj.z, v2Proj.w));
+    glm::vec3 ndcv3Proj = glm::vec3(__fdividef(v3Proj.x, v3Proj.w), __fdividef(v3Proj.y, v3Proj.w), __fdividef(v3Proj.z, v3Proj.w));
+    glm::vec3 ndcv4Proj = glm::vec3(__fdividef(v4Proj.x, v4Proj.w), __fdividef(v4Proj.y, v4Proj.w), __fdividef(v4Proj.z, v4Proj.w));
+
+    projectedPoints[0] = glm::vec2(ndcv1Proj);
+    projectedPoints[1] = glm::vec2(ndcv2Proj);
+    projectedPoints[2] = glm::vec2(ndcv4Proj);
+    projectedPoints[3] = glm::vec2(ndcv3Proj);
+}
+
+__global__ void sphereFrustumBBoxClassifyKernel(
+    const glm::vec4* __restrict__ spheres,
+    unsigned int* __restrict__ smallSphereIndices,
+    unsigned int* __restrict__ smallSphereCount,
+    TileSphereIDPairs* __restrict__ largeSphereTilePairs,
+    unsigned int* __restrict__ largeSphereCount,
+    unsigned int* __restrict__ frustumPassedCount)
+{
+    const unsigned int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= hybridCst.sphereCount) return;
+    
+    glm::vec4 spherePosR = spheres[idx];
+    if (!isSphereInsideFrustum(spherePosR)) return;
+    
+    if (hybridCst.benchmark) atomicAdd(frustumPassedCount, 1u);
+    
+    glm::vec2 screenMin, screenMax;
+    float centerDepth;
+    computeSphereBBox(spherePosR, screenMin, screenMax, centerDepth);
+    
+    float width = screenMax.x - screenMin.x;
+    float height = screenMax.y - screenMin.y;
+    float area = width * height;
+    if (area < 1.0f) return;
+    
+    if (area <= (float)hybridCst.smallEntityThreshold) {
+        unsigned int outIdx = atomicAdd(smallSphereCount, 1u);
+        smallSphereIndices[outIdx] = idx;
+    } else {
+        atomicAdd(largeSphereCount, 1u);
+        addTileSphereIDPair(largeSphereTilePairs, idx, screenMin, screenMax);
+    }
+}
+
+// Compute area of quadrilateral using shoelace formula
+__device__ inline float quadArea(const glm::vec2& q0, const glm::vec2& q1, const glm::vec2& q2, const glm::vec2& q3) 
+{
+    return 0.5f * fabsf(
+        (q0.x * q1.y - q1.x * q0.y) +
+        (q1.x * q2.y - q2.x * q1.y) +
+        (q2.x * q3.y - q3.x * q2.y) +
+        (q3.x * q0.y - q0.x * q3.y)
+    );
+}
+
+__global__ void cylinderFrustumBBoxClassifyKernel(
+    const Cylinder* __restrict__ cylinders,
+    unsigned int* __restrict__ smallCylinderIndices,
+    unsigned int* __restrict__ smallCylinderCount,
+    TileCylinderIDPairs* __restrict__ largeCylinderTilePairs,
+    unsigned int* __restrict__ largeCylinderCount,
+    unsigned int* __restrict__ frustumPassedCount)
+{
+    const unsigned int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= hybridCst.cylinderCount) return;
+    
+    Cylinder cyl = cylinders[idx];
+    glm::vec3 pa = glm::vec3(cyl.pa_r);
+    glm::vec3 pb = glm::vec3(cyl.pb_r);
+    float radius = cyl.pa_r.w;
+    if (!isCylinderInsideFrustum(pa, pb, radius)) return;
+    
+    if (hybridCst.benchmark) atomicAdd(frustumPassedCount, 1u);
+    
+    glm::vec2 projectedPoints[4];
+    computeCylinderBBox(pa, pb, radius, projectedPoints);
+
+    // Convert NDC to screen coordinates
+    for (int i = 0; i < 4; i++) 
+    {
+        projectedPoints[i].x = (projectedPoints[i].x * 0.5f + 0.5f) * (float)hybridCst.screenWidth;
+        projectedPoints[i].y = (projectedPoints[i].y * 0.5f + 0.5f) * (float)hybridCst.screenHeight;
+        projectedPoints[i] = glm::clamp(projectedPoints[i], glm::vec2(0.0f), glm::vec2((float)hybridCst.screenWidth, (float)hybridCst.screenHeight));
+    }
+    
+    float area = quadArea(projectedPoints[0], projectedPoints[1], projectedPoints[2], projectedPoints[3]);
+    if (area < 1.0f) return;
+    
+    if (area <= (float)hybridCst.smallEntityThreshold) {
+        unsigned int outIdx = atomicAdd(smallCylinderCount, 1u);
+        smallCylinderIndices[outIdx] = idx;
+    } else {
+        atomicAdd(largeCylinderCount, 1u);
+        addTileSphereIDPair(largeCylinderTilePairs, idx, screenMin, screenMax);
+    }
+}
+
+extern "C" void uploadHybridConstants(const HybridConstants& constants, cudaStream_t stream) {
+    cudaMemcpyToSymbolAsync(hybridCst, &constants, sizeof(HybridConstants), 0, cudaMemcpyHostToDevice, stream);
+}
+
+extern "C" void launchSphereFrustumBBoxClassify(
+    const glm::vec4* d_spheres,
+    unsigned int* d_smallSphereIndices,
+    unsigned int* d_smallSphereCount,
+    SphereBillboard* d_largeBillboards,
+    unsigned int* d_largeSphereCount,
+    unsigned int* d_frustumPassedCount,
+    int sphereCount,
+    cudaStream_t stream)
+{
+    dim3 block(CULL_BLOCK_SIZE);
+    dim3 grid((sphereCount + block.x - 1) / block.x);
+    sphereFrustumBBoxClassifyKernel<<<grid, block, 0, stream>>>(
+        d_spheres, d_smallSphereIndices, d_smallSphereCount,
+        d_largeBillboards, d_largeSphereCount, d_frustumPassedCount);
+}
+
+extern "C" void launchCylinderFrustumBBoxClassify(
+    const Cylinder* d_cylinders,
+    unsigned int* d_smallCylinderIndices,
+    unsigned int* d_smallCylinderCount,
+    CylinderBillboard* d_largeBillboards,
+    unsigned int* d_largeCylinderCount,
+    unsigned int* d_frustumPassedCount,
+    int cylinderCount,
+    cudaStream_t stream)
+{
+    dim3 block(CULL_BLOCK_SIZE);
+    dim3 grid((cylinderCount + block.x - 1) / block.x);
+    cylinderFrustumBBoxClassifyKernel<<<grid, block, 0, stream>>>(
+        d_cylinders, d_smallCylinderIndices, d_smallCylinderCount,
+        d_largeBillboards, d_largeCylinderCount, d_frustumPassedCount);
+}

--- a/kernels/hybrid_binning/generate_pairs.cu
+++ b/kernels/hybrid_binning/generate_pairs.cu
@@ -1,0 +1,92 @@
+/**
+ * @file generate_pairs.cu
+ * @brief Generate (TileID, EntityID) pairs for binning-by-sort.
+ * Each large entity emits one pair per overlapping tile; atomic counter for output index.
+ */
+
+#include <cuda_runtime.h>
+#include <device_launch_parameters.h>
+
+#include "hybrid_binning_types.h"
+
+extern __constant__ HybridConstants hybridCst;
+
+__global__ void generateSpherePairsKernel(
+    const SphereBillboard* __restrict__ billboards,
+    unsigned int billboardCount,
+    unsigned int* __restrict__ d_keys,    // TileID
+    unsigned int* __restrict__ d_values,  // EntityID (original index)
+    unsigned int* __restrict__ d_pairCount)
+{
+    const unsigned int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= billboardCount) return;
+    
+    const SphereBillboard& bb = billboards[idx];
+    unsigned int entityId = bb.originalIndex;
+    
+    for (unsigned int ty = bb.tileMinY; ty <= bb.tileMaxY; ++ty) {
+        for (unsigned int tx = bb.tileMinX; tx <= bb.tileMaxX; ++tx) {
+            unsigned int tileId = ty * hybridCst.tilesX + tx;
+            unsigned int outIdx = atomicAdd(d_pairCount, 1u);
+            d_keys[outIdx] = tileId;
+            d_values[outIdx] = entityId;
+        }
+    }
+}
+
+__global__ void generateCylinderPairsKernel(
+    const CylinderBillboard* __restrict__ billboards,
+    unsigned int billboardCount,
+    unsigned int* __restrict__ d_keys,
+    unsigned int* __restrict__ d_values,
+    unsigned int* __restrict__ d_pairCount)
+{
+    const unsigned int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= billboardCount) return;
+    
+    const CylinderBillboard& bb = billboards[idx];
+    unsigned int entityId = bb.originalIndex;
+    
+    for (unsigned int ty = bb.tileMinY; ty <= bb.tileMaxY; ++ty) {
+        for (unsigned int tx = bb.tileMinX; tx <= bb.tileMaxX; ++tx) {
+            unsigned int tileId = ty * hybridCst.tilesX + tx;
+            unsigned int outIdx = atomicAdd(d_pairCount, 1u);
+            d_keys[outIdx] = tileId;
+            d_values[outIdx] = entityId;
+        }
+    }
+}
+
+extern "C" void launchGenerateSpherePairs(
+    const SphereBillboard* d_billboards,
+    unsigned int billboardCount,
+    unsigned int* d_keys,
+    unsigned int* d_values,
+    unsigned int* d_pairCount,
+    cudaStream_t stream)
+{
+    if (billboardCount == 0) return;
+    cudaMemsetAsync(d_pairCount, 0, sizeof(unsigned int), stream);
+    
+    dim3 block(256);
+    dim3 grid((billboardCount + block.x - 1) / block.x);
+    generateSpherePairsKernel<<<grid, block, 0, stream>>>(
+        d_billboards, billboardCount, d_keys, d_values, d_pairCount);
+}
+
+extern "C" void launchGenerateCylinderPairs(
+    const CylinderBillboard* d_billboards,
+    unsigned int billboardCount,
+    unsigned int* d_keys,
+    unsigned int* d_values,
+    unsigned int* d_pairCount,
+    cudaStream_t stream)
+{
+    if (billboardCount == 0) return;
+    cudaMemsetAsync(d_pairCount, 0, sizeof(unsigned int), stream);
+    
+    dim3 block(256);
+    dim3 grid((billboardCount + block.x - 1) / block.x);
+    generateCylinderPairsKernel<<<grid, block, 0, stream>>>(
+        d_billboards, billboardCount, d_keys, d_values, d_pairCount);
+}

--- a/kernels/hybrid_binning/hybrid_binning_types.h
+++ b/kernels/hybrid_binning/hybrid_binning_types.h
@@ -12,6 +12,8 @@
 
 #define SMALL_ENTITY_THRESHOLD 256
 #define TILE_SIZE 16
+/** Average entities per tile for pair buffer sizing: buffer size = AVG_ENTITIES_PER_TILE * totalTiles */
+#define AVG_ENTITIES_PER_TILE 500
 #define TILE_SIZE_SHIFT 4
 #define CULL_BLOCK_SIZE 256
 #define SMALL_RASTER_BLOCK_SIZE 256
@@ -44,7 +46,7 @@ struct CylinderBillboard {
     unsigned int tileMaxY;
 };
 
-struct BBox3D
+struct _BBox3D
 {
     glm::vec3 mMin;
     glm::vec3 mMax;
@@ -68,6 +70,13 @@ struct HybridConstants {
     int totalTiles;
     int smallEntityThreshold;
     int benchmark;
+    /** Max (tile_id, entity_id) pairs = avgEntitiesPerTile * totalTiles */
+    int avgEntitiesPerTile;
 };
+
+/** Device-side color constants for raster (atoms/bonds); defined in small_entity_raster.cu */
+extern __device__ __constant__ float atomsColor[3];
+extern __device__ __constant__ float bondsColor[3];
+extern __device__ __constant__ float diffuse;
 
 #endif

--- a/kernels/hybrid_binning/hybrid_binning_types.h
+++ b/kernels/hybrid_binning/hybrid_binning_types.h
@@ -1,0 +1,73 @@
+/**
+ * @file hybrid_binning_types.h
+ * @brief Shared types for hybrid binning-by-sort pipeline (no linked lists).
+ * Uses CUB DeviceRadixSort + DeviceRunLengthEncode for tile binning.
+ */
+
+#ifndef HYBRID_BINNING_TYPES_H
+#define HYBRID_BINNING_TYPES_H
+
+#include <cuda_runtime.h>
+#include <glm/glm.hpp>
+
+#define SMALL_ENTITY_THRESHOLD 256
+#define TILE_SIZE 16
+#define TILE_SIZE_SHIFT 4
+#define CULL_BLOCK_SIZE 256
+#define SMALL_RASTER_BLOCK_SIZE 256
+#define TILE_BLOCK_SIZE_X 16
+#define TILE_BLOCK_SIZE_Y 16
+#define SHARED_BATCH_SIZE 64
+
+struct SphereBillboard {
+    glm::vec4 positionRadius;
+    glm::vec2 screenMin;
+    glm::vec2 screenMax;
+    float centerDepth;
+    unsigned int originalIndex;
+    unsigned int tileMinX;
+    unsigned int tileMinY;
+    unsigned int tileMaxX;
+    unsigned int tileMaxY;
+};
+
+struct CylinderBillboard {
+    glm::vec4 pa_r;
+    glm::vec4 pb_r;
+    glm::vec2 screenMin;
+    glm::vec2 screenMax;
+    float centerDepth;
+    unsigned int originalIndex;
+    unsigned int tileMinX;
+    unsigned int tileMinY;
+    unsigned int tileMaxX;
+    unsigned int tileMaxY;
+};
+
+struct BBox3D
+{
+    glm::vec3 mMin;
+    glm::vec3 mMax;
+};
+
+struct HybridConstants {
+    glm::mat4 view;
+    glm::mat4 proj;
+    glm::vec4 frustumPlanes[6];
+    glm::vec3 front;
+    glm::vec3 up;
+    glm::vec3 right;
+    glm::vec3 cameraPos;
+    int screenWidth;
+    int screenHeight;
+    float fov;
+    int sphereCount;
+    int cylinderCount;
+    int tilesX;
+    int tilesY;
+    int totalTiles;
+    int smallEntityThreshold;
+    int benchmark;
+};
+
+#endif

--- a/kernels/hybrid_binning/hybrid_binning_types.h
+++ b/kernels/hybrid_binning/hybrid_binning_types.h
@@ -72,6 +72,14 @@ struct HybridConstants {
     int benchmark;
     /** Max (tile_id, entity_id) pairs = avgEntitiesPerTile * totalTiles */
     int avgEntitiesPerTile;
+
+    /** Pre-computed screen ray casting vectors (camera space).
+     *  ray(px,py) = rayStart + px*dx + py*dy  (unnormalized direction).
+     *  Hit point in camera space: hit = ray(px,py) * t.
+     *  Depth from camera-space hit: (hit.z * proj[2][2] + proj[3][2]) / -hit.z */
+    glm::vec3 rayStart; ///< Corner (0,0) ray direction in camera space
+    glm::vec3 dx;       ///< Per-pixel delta along x in camera space
+    glm::vec3 dy;       ///< Per-pixel delta along y in camera space
 };
 
 /** Device-side color constants for raster (atoms/bonds); defined in small_entity_raster.cu */

--- a/kernels/hybrid_binning/screen_clear.cu
+++ b/kernels/hybrid_binning/screen_clear.cu
@@ -1,0 +1,35 @@
+/**
+ * @file screen_clear.cu
+ * @brief Screen clearing for hybrid binning pipeline.
+ */
+
+#include <cuda_runtime.h>
+#include <device_launch_parameters.h>
+
+__global__ void clearScreenKernel(
+    cudaSurfaceObject_t outputImage,
+    unsigned int* __restrict__ depthBuffer,
+    unsigned int screenWidth,
+    unsigned int screenHeight,
+    float farPlane)
+{
+    unsigned int px = blockIdx.x * blockDim.x + threadIdx.x;
+    unsigned int py = blockIdx.y * blockDim.y + threadIdx.y;
+    if (px >= screenWidth || py >= screenHeight) return;
+    uchar4 clearColor = make_uchar4(0, 0, 0, 255);
+    surf2Dwrite(clearColor, outputImage, px * sizeof(uchar4), py);
+    depthBuffer[py * screenWidth + px] = __float_as_uint(farPlane);
+}
+
+extern "C" void launchScreenClear(
+    cudaSurfaceObject_t outputImage,
+    unsigned int* d_depthBuffer,
+    unsigned int screenWidth,
+    unsigned int screenHeight,
+    float farPlane,
+    cudaStream_t stream)
+{
+    dim3 block(16, 16);
+    dim3 grid((screenWidth + block.x - 1) / block.x, (screenHeight + block.y - 1) / block.y);
+    clearScreenKernel<<<grid, block, 0, stream>>>(outputImage, d_depthBuffer, screenWidth, screenHeight, farPlane);
+}

--- a/kernels/hybrid_binning/screen_clear.cu
+++ b/kernels/hybrid_binning/screen_clear.cu
@@ -16,7 +16,7 @@ __global__ void clearScreenKernel(
     unsigned int px = blockIdx.x * blockDim.x + threadIdx.x;
     unsigned int py = blockIdx.y * blockDim.y + threadIdx.y;
     if (px >= screenWidth || py >= screenHeight) return;
-    uchar4 clearColor = make_uchar4(0, 0, 0, 255);
+    uchar4 clearColor = make_uchar4(255, 255, 0, 255);
     surf2Dwrite(clearColor, outputImage, px * sizeof(uchar4), py);
     depthBuffer[py * screenWidth + px] = __float_as_uint(farPlane);
 }

--- a/kernels/hybrid_binning/small_entity_raster.cu
+++ b/kernels/hybrid_binning/small_entity_raster.cu
@@ -50,7 +50,8 @@ __device__ inline glm::vec4 iCylinder(const glm::vec3& ro, const glm::vec3& rd,
 
     // body
     float y = fmaf(t, bard, baoc);
-    if( y>0.0f && y<baba ) return glm::vec4( t, oc+t*rd - ba*y/baba );
+    if( y>0.0f && y<baba ) 
+        return glm::vec4( t, oc+t*rd - ba*y/baba );
     
     // caps
     // t = ( ((y<0.0f) ? 0.0f : baba) - baoc)/bard;
@@ -202,7 +203,7 @@ __global__ void smallCylinderRasterKernel(
     const float sinAngle = __fdividef(radius, dV0);
     float		angle	 = asinf( sinAngle );
     const glm::vec3	y1		 = y * radius;
-    const glm::vec3	x2		 = x * radius * cosf( angle );
+    const glm::vec3	x2		 = x * radius * __cosf( angle );
     const glm::vec3	y2		 = y1 * sinAngle;
     angle				 = asinf( __fdividef(radius, dV1) );
     const glm::vec3 x3		 = x * ( dV1 - radius ) * __tanf( angle );
@@ -244,9 +245,6 @@ __global__ void smallCylinderRasterKernel(
         minX = min(minX, __float2int_rd(projectedPoints[i].x)); 
         maxX = max(maxX, __float2int_ru(projectedPoints[i].x));
     }
-
-    if (maxY < 0 || minY >= hybridCst.screenHeight || maxY - minY < 2 ||
-        maxX < 0 || minX >= hybridCst.screenWidth || maxX - minX < 2) return;
     
 
     float aspectRatio = fdividef(hybridCst.screenWidth, hybridCst.screenHeight);
@@ -284,7 +282,7 @@ __global__ void smallCylinderRasterKernel(
                 xMax = fmaxf(xMax, xIntersections[i]);
             }
             glm::vec3 rayColStart = hybridCst.rayStart + (float)py * hybridCst.dy;
-            for (int px = fmaxf(0, __float2int_ru(xMin)); px <= fminf(__float2int_rd(xMax), hybridCst.screenWidth -1); ++px)
+            for (int px = max(0, __float2int_ru(xMin)); px <= min(__float2int_rd(xMax), hybridCst.screenWidth -1); ++px)
             {
                 glm::vec3 rd = computeRayDirection(px, py, fovTan, halfFovTan);
                 glm::vec4 tnor = iCylinder(glm::vec3(hybridCst.cameraPos), rd, pa, pb, radius);

--- a/kernels/hybrid_binning/small_entity_raster.cu
+++ b/kernels/hybrid_binning/small_entity_raster.cu
@@ -1,0 +1,202 @@
+/**
+ * @file small_entity_raster.cu
+ * @brief Direct rasterization for small entities (1 thread per entity). Same as hybrid.
+ */
+
+#include <cuda_runtime.h>
+#include <device_launch_parameters.h>
+#include <glm/glm.hpp>
+
+#include "hybrid_binning_types.h"
+#include "geometry/cylinder/cylinder.h"
+
+extern __constant__ HybridConstants hybridCst;
+
+__device__ inline float iSphere(const glm::vec3& ro, const glm::vec3& rd,
+                                const glm::vec3& center, float radius) {
+    glm::vec3 oc = ro - center;
+    float b = glm::dot(oc, rd);
+    float c = glm::dot(oc, oc) - radius * radius;
+    float h = b * b - c;
+    if (h < 0.0f) return -1.0f;
+    return -b - sqrtf(h);
+}
+
+__device__ inline glm::vec2 iCylinder(const glm::vec3& ro, const glm::vec3& rd,
+                                      const glm::vec3& pa, const glm::vec3& pb, float ra) {
+    glm::vec3 ba = pb - pa, oc = ro - pa;
+    float baba = glm::dot(ba, ba), bard = glm::dot(ba, rd), baoc = glm::dot(ba, oc);
+    float k2 = baba - bard * bard;
+    float k1 = baba * glm::dot(oc, rd) - baoc * bard;
+    float k0 = baba * glm::dot(oc, oc) - baoc * baoc - ra * ra * baba;
+    float h = k1 * k1 - k2 * k0;
+    if (h < 0.0f) return glm::vec2(-1.0f);
+    h = sqrtf(h);
+    float t = (-k1 - h) / k2;
+    float y = baoc + t * bard;
+    if (y > 0.0f && y < baba) return glm::vec2(t, y / baba);
+    t = ((y < 0.0f ? 0.0f : baba) - baoc) / bard;
+    if (fabsf(k1 + k2 * t) < h) return glm::vec2(t, y < 0.0f ? 0.0f : 1.0f);
+    return glm::vec2(-1.0f);
+}
+
+__device__ inline glm::vec3 computeRayDirection(int px, int py, float fovTan, float halfFovTan) {
+    glm::vec2 p = (-glm::vec2(hybridCst.screenWidth, hybridCst.screenHeight) +
+                   2.0f * glm::vec2(px, py)) / glm::vec2(hybridCst.screenWidth, hybridCst.screenHeight);
+    return glm::normalize(p.x * hybridCst.right * halfFovTan + p.y * hybridCst.up * fovTan + hybridCst.front);
+}
+
+__global__ void smallSphereRasterKernel(
+    const glm::vec4* __restrict__ spheres,
+    const unsigned int* __restrict__ smallSphereIndices,
+    unsigned int smallSphereCount,
+    unsigned int* __restrict__ depthBuffer,
+    cudaSurfaceObject_t outputImage)
+{
+    unsigned int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= smallSphereCount) return;
+    unsigned int sphereIdx = smallSphereIndices[idx];
+    glm::vec4 spherePosR = spheres[sphereIdx];
+    glm::vec3 spherePos = glm::vec3(spherePosR);
+    float radius = spherePosR.w;
+    glm::vec4 camSpace4 = hybridCst.view * glm::vec4(spherePos, 1.0f);
+    glm::vec3 cameraSpaceSphere = glm::vec3(camSpace4);
+    glm::vec3 normCamSpaceSphere = glm::normalize(cameraSpaceSphere);
+    glm::vec3 camImposPos = cameraSpaceSphere - normCamSpaceSphere * radius;
+    float dist = glm::length(cameraSpaceSphere) + 1e-6f;
+    float sinAngle = radius / dist;
+    float tanAngle = tanf(asinf(fminf(sinAngle, 0.999f)));
+    float quadScale = tanAngle * glm::length(camImposPos);
+    glm::vec3 upVec(0.0f, 1.0f, 0.0f);
+    glm::vec3 impU = glm::normalize(glm::cross(normCamSpaceSphere, upVec));
+    if (glm::length(impU) < 0.001f) impU = glm::vec3(1.0f, 0.0f, 0.0f);
+    glm::vec3 impV = glm::cross(impU, normCamSpaceSphere) * quadScale;
+    impU *= quadScale;
+    glm::vec3 corners[4] = {
+        camImposPos + impU + impV, camImposPos - impU + impV,
+        camImposPos + impU - impV, camImposPos - impU - impV
+    };
+    glm::vec2 minC(1e6f), maxC(-1e6f);
+    for (int i = 0; i < 4; i++) {
+        glm::vec4 clip = hybridCst.proj * glm::vec4(corners[i], 1.0f);
+        float iw = 1.0f / clip.w;
+        minC.x = fminf(minC.x, clip.x * iw); minC.y = fminf(minC.y, clip.y * iw);
+        maxC.x = fmaxf(maxC.x, clip.x * iw); maxC.y = fmaxf(maxC.y, clip.y * iw);
+    }
+    int screenMinX = max(0, (int)floorf((minC.x * 0.5f + 0.5f) * hybridCst.screenWidth));
+    int screenMinY = max(0, (int)floorf((minC.y * 0.5f + 0.5f) * hybridCst.screenHeight));
+    int screenMaxX = min(hybridCst.screenWidth, (int)ceilf((maxC.x * 0.5f + 0.5f) * hybridCst.screenWidth));
+    int screenMaxY = min(hybridCst.screenHeight, (int)ceilf((maxC.y * 0.5f + 0.5f) * hybridCst.screenHeight));
+    float aspectRatio = (float)hybridCst.screenWidth / (float)hybridCst.screenHeight;
+    float fovRad = glm::radians(hybridCst.fov);
+    float fovTan = tanf(fovRad * 0.5f);
+    float halfFovTan = fovTan * aspectRatio;
+    for (int py = screenMinY; py < screenMaxY; py++) {
+        for (int px = screenMinX; px < screenMaxX; px++) {
+            glm::vec3 rd = computeRayDirection(px, py, fovTan, halfFovTan);
+            float t = iSphere(hybridCst.cameraPos, rd, spherePos, radius);
+            if (t > 0.0f) {
+                glm::vec3 hit = hybridCst.cameraPos + rd * t;
+                glm::vec4 hitClip = hybridCst.proj * (hybridCst.view * glm::vec4(hit, 1.0f));
+                float depth = hitClip.z / hitClip.w;
+                unsigned int depthU = __float_as_uint(depth);
+                int pixelIdx = py * hybridCst.screenWidth + px;
+                if (atomicMin(&depthBuffer[pixelIdx], depthU) != depthU) {
+                    glm::vec3 normal = glm::normalize(hit - spherePos);
+                    float lambert = fmaxf(0.0f, glm::dot(normal, -glm::normalize(rd)));
+                    glm::vec3 color = glm::vec3(0.01f, 1.0f, 0.05f) * lambert * 0.9f;
+                    uchar4 pixel = make_uchar4((unsigned char)(color.x * 255.0f), (unsigned char)(color.y * 255.0f), (unsigned char)(color.z * 255.0f), 255);
+                    surf2Dwrite(pixel, outputImage, px * sizeof(uchar4), py);
+                }
+            }
+        }
+    }
+}
+
+__global__ void smallCylinderRasterKernel(
+    const Cylinder* __restrict__ cylinders,
+    const unsigned int* __restrict__ smallCylinderIndices,
+    unsigned int smallCylinderCount,
+    unsigned int* __restrict__ depthBuffer,
+    cudaSurfaceObject_t outputImage)
+{
+    unsigned int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= smallCylinderCount) return;
+    unsigned int cylIdx = smallCylinderIndices[idx];
+    Cylinder cyl = cylinders[cylIdx];
+    glm::vec3 pa = glm::vec3(cyl.pa_r), pb = glm::vec3(cyl.pb_r);
+    float radius = cyl.pa_r.w;
+    glm::vec4 camA = hybridCst.view * glm::vec4(pa, 1.0f);
+    glm::vec4 camB = hybridCst.view * glm::vec4(pb, 1.0f);
+    glm::vec3 axis = glm::vec3(camB) - glm::vec3(camA);
+    float axisLenSq = glm::dot(axis, axis);
+    glm::vec3 e = radius * glm::sqrt(glm::max(glm::vec3(0.001f), glm::vec3(1.0f) - axis * axis / axisLenSq));
+    glm::vec3 pts[4] = { glm::vec3(camA) + e, glm::vec3(camA) - e, glm::vec3(camB) + e, glm::vec3(camB) - e };
+    glm::vec2 minC(1e6f), maxC(-1e6f);
+    for (int i = 0; i < 4; i++) {
+        glm::vec4 clip = hybridCst.proj * glm::vec4(pts[i], 1.0f);
+        if (clip.w > 0.001f) {
+            float iw = 1.0f / clip.w;
+            minC.x = fminf(minC.x, clip.x * iw); minC.y = fminf(minC.y, clip.y * iw);
+            maxC.x = fmaxf(maxC.x, clip.x * iw); maxC.y = fmaxf(maxC.y, clip.y * iw);
+        }
+    }
+    int screenMinX = max(0, (int)floorf((minC.x * 0.5f + 0.5f) * hybridCst.screenWidth));
+    int screenMinY = max(0, (int)floorf((minC.y * 0.5f + 0.5f) * hybridCst.screenHeight));
+    int screenMaxX = min(hybridCst.screenWidth, (int)ceilf((maxC.x * 0.5f + 0.5f) * hybridCst.screenWidth));
+    int screenMaxY = min(hybridCst.screenHeight, (int)ceilf((maxC.y * 0.5f + 0.5f) * hybridCst.screenHeight));
+    float aspectRatio = (float)hybridCst.screenWidth / (float)hybridCst.screenHeight;
+    float fovRad = glm::radians(hybridCst.fov);
+    float fovTan = tanf(fovRad * 0.5f);
+    float halfFovTan = fovTan * aspectRatio;
+    for (int py = screenMinY; py < screenMaxY; py++) {
+        for (int px = screenMinX; px < screenMaxX; px++) {
+            glm::vec3 rd = computeRayDirection(px, py, fovTan, halfFovTan);
+            glm::vec2 result = iCylinder(hybridCst.cameraPos, rd, pa, pb, radius);
+            if (result.x > 0.0f) {
+                glm::vec3 hit = hybridCst.cameraPos + rd * result.x;
+                glm::vec4 hitClip = hybridCst.proj * (hybridCst.view * glm::vec4(hit, 1.0f));
+                float depth = hitClip.z / hitClip.w;
+                unsigned int depthU = __float_as_uint(depth);
+                int pixelIdx = py * hybridCst.screenWidth + px;
+                if (atomicMin(&depthBuffer[pixelIdx], depthU) != depthU) {
+                    glm::vec3 ba = pb - pa, hitLocal = hit - pa;
+                    float h = glm::dot(hitLocal, ba) / glm::dot(ba, ba);
+                    glm::vec3 normal = glm::normalize(hitLocal - ba * glm::clamp(h, 0.0f, 1.0f));
+                    float lambert = fmaxf(0.0f, glm::dot(normal, -glm::normalize(rd)));
+                    glm::vec3 color = glm::vec3(0.01f, 1.0f, 0.05f) * lambert * 0.9f;
+                    uchar4 pixel = make_uchar4((unsigned char)(color.x * 255.0f), (unsigned char)(color.y * 255.0f), (unsigned char)(color.z * 255.0f), 255);
+                    surf2Dwrite(pixel, outputImage, px * sizeof(uchar4), py);
+                }
+            }
+        }
+    }
+}
+
+extern "C" void launchSmallSphereRaster(
+    const glm::vec4* d_spheres,
+    const unsigned int* d_smallSphereIndices,
+    unsigned int smallSphereCount,
+    unsigned int* d_depthBuffer,
+    cudaSurfaceObject_t outputImage,
+    cudaStream_t stream)
+{
+    if (smallSphereCount == 0) return;
+    dim3 block(256);
+    dim3 grid((smallSphereCount + block.x - 1) / block.x);
+    smallSphereRasterKernel<<<grid, block, 0, stream>>>(d_spheres, d_smallSphereIndices, smallSphereCount, d_depthBuffer, outputImage);
+}
+
+extern "C" void launchSmallCylinderRaster(
+    const Cylinder* d_cylinders,
+    const unsigned int* d_smallCylinderIndices,
+    unsigned int smallCylinderCount,
+    unsigned int* d_depthBuffer,
+    cudaSurfaceObject_t outputImage,
+    cudaStream_t stream)
+{
+    if (smallCylinderCount == 0) return;
+    dim3 block(256);
+    dim3 grid((smallCylinderCount + block.x - 1) / block.x);
+    smallCylinderRasterKernel<<<grid, block, 0, stream>>>(d_cylinders, d_smallCylinderIndices, smallCylinderCount, d_depthBuffer, outputImage);
+}

--- a/kernels/hybrid_binning/small_entity_raster.cu
+++ b/kernels/hybrid_binning/small_entity_raster.cu
@@ -60,10 +60,8 @@ __device__ inline glm::vec4 iCylinder(const glm::vec3& ro, const glm::vec3& rd,
     return glm::vec4(-1.0f);
 }
 
-__device__ inline glm::vec3 computeRayDirection(int px, int py, float fovTan, float halfFovTan) {
-    glm::vec2 p = (-glm::vec2(hybridCst.screenWidth, hybridCst.screenHeight) +
-                   2.0f * glm::vec2(px, py)) / glm::vec2(hybridCst.screenWidth, hybridCst.screenHeight);
-    return glm::normalize(p.x * hybridCst.right * halfFovTan + p.y * hybridCst.up * fovTan + hybridCst.front);
+__device__ inline glm::vec3 fastNormalize(const glm::vec3& v) {
+    return v * rsqrtf(glm::dot(v, v));
 }
 
 __global__ void smallSphereRasterKernel(
@@ -76,7 +74,7 @@ __global__ void smallSphereRasterKernel(
     unsigned int idx = blockIdx.x * blockDim.x + threadIdx.x;
     if (idx >= smallSphereCount) return;
 
-    unsigned int sphereIdx = smallSphereIndices[idx];
+    unsigned int sphereIdx = __ldg(&smallSphereIndices[idx]);
 
     glm::vec4 spherePosR = spheres[sphereIdx];
     glm::vec3 spherePos = glm::vec3(spherePosR);
@@ -124,31 +122,26 @@ __global__ void smallSphereRasterKernel(
     float dify = float(screenMaxY - screenMinY);
     if (difx * dify <= 2.0f) return;
 
-    float aspectRatio = __fdividef(float(hybridCst.screenWidth), float(hybridCst.screenHeight));
-    float fovRad = glm::radians(hybridCst.fov);
-    float fovTan = __tanf(fovRad * 0.5f);
-    float halfFovTan = fovTan * aspectRatio;
-
-
     float proj22 = hybridCst.proj[2][2];
     float proj32 = hybridCst.proj[3][2];
 
     for (int py = screenMinY; py < screenMaxY; py++) {
         glm::vec3 rayColStart = hybridCst.rayStart + (float)py * hybridCst.dy;
         for (int px = screenMinX; px < screenMaxX; px++) {
-            glm::vec3 rd = computeRayDirection(px, py, fovTan, halfFovTan);
+            glm::vec3 ray = rayColStart + (float)px * hybridCst.dx;
+            glm::vec3 rd = fastNormalize(ray.x * hybridCst.right + ray.y * hybridCst.up - ray.z * hybridCst.front);
             float t = iSphere(hybridCst.cameraPos, rd, spherePos, radius);
 
             if (t > 0.0f) {
-                glm::vec3 hit = (rayColStart + (float)px * hybridCst.dx) * t;
+                glm::vec3 hit = ray * t;
                 float depth = __fdividef(fmaf(hit.z, proj22, proj32), -hit.z);
                 unsigned int depthU = __float_as_uint(depth);
 
                 int pixelIdx = py * hybridCst.screenWidth + px;
                 unsigned int old = atomicMin(&depthBuffer[pixelIdx], depthU);
                 if (__uint_as_float(old) > depth) {
-                    glm::vec3 normal = glm::normalize(hybridCst.cameraPos + rd * t - glm::vec3(spherePosR));
-                    float lambert = fmaxf(0.0f, glm::dot(normal, -glm::normalize(rd * t)));
+                    glm::vec3 normal = fastNormalize(hybridCst.cameraPos + rd * t - glm::vec3(spherePosR));
+                    float lambert = fmaxf(0.0f, glm::dot(normal, -rd));
                     glm::vec3 color = glm::vec3(atomsColor[0], atomsColor[1], atomsColor[2]) * lambert * diffuse;
                     uchar4 ucharColor = make_uchar4(
                         (unsigned char)(color.x * 255.0f),
@@ -170,7 +163,7 @@ __global__ void smallCylinderRasterKernel(
 {
     unsigned int idx = blockIdx.x * blockDim.x + threadIdx.x;
     if (idx >= smallCylinderCount) return;
-    unsigned int cylIdx = smallCylinderIndices[idx];
+    unsigned int cylIdx = __ldg(&smallCylinderIndices[idx]);
     Cylinder cyl = cylinders[cylIdx];
     glm::vec3 pa = glm::vec3(cyl.pa_r), pb = glm::vec3(cyl.pb_r);
     float radius = cyl.pa_r.w;
@@ -247,50 +240,57 @@ __global__ void smallCylinderRasterKernel(
     }
     
 
-    float aspectRatio = fdividef(hybridCst.screenWidth, hybridCst.screenHeight);
-    float fovRad = glm::radians(hybridCst.fov);
-    float fovTan = __tanf(fovRad * 0.5f);
-    float halfFovTan = fovTan * aspectRatio;
-
     for (int py = fminf(hybridCst.screenHeight-1, maxY); py >= fmaxf(0, minY); --py)
     {
-        float xIntersections[4];
-        int intersections = 0;
 
+        
+        float fpy = float(py) + 0.5f; // Centro del pixel en Y
+        
+        // Encontrar startX y endX para esta fila específica
+        // Inicializamos invertidos para acumular min/max
+        float rowMinX = float(hybridCst.screenWidth);
+        float rowMaxX = -1.0f;
+        
+        // Recorremos las 4 aristas del polígono proyectado (unroll manual o loop corto)
         #pragma unroll 4
         for (int i = 0; i < 4; ++i) 
         {
-            const glm::vec2 a = projectedPoints[i];
-            const glm::vec2 b = projectedPoints[(i + 1) % 4];
+            glm::vec2 v1 = projectedPoints[i];
+            glm::vec2 v2 = projectedPoints[(i + 1) % 4];
 
-            if ((py >= a.y && py <= b.y) || (py >= b.y && py <= a.y)) 
+            // Comprobar si la linea cruza esta fila Y
+            // Nota: Usamos (>= y <) para evitar doble conteo en vértices exactos
+            bool crossing = (v1.y <= fpy && v2.y > fpy) || (v2.y <= fpy && v1.y > fpy);
+            
+            if (crossing) 
             {
-                float x = intersectX(a, b, py);
-                xIntersections[intersections] = x;
-                intersections++;
+                // Calcular intersección X sin llamadas a funciones externas
+                float t = (fpy - v1.y) / (v2.y - v1.y);
+                float intersectX = v1.x + t * (v2.x - v1.x);
+                
+                rowMinX = min(rowMinX, intersectX);
+                rowMaxX = max(rowMaxX, intersectX);
             }
         }
 
-        if (intersections >= 2)
-        {
-            float xMin = xIntersections[0];
-            float xMax = xIntersections[0];
+        // Convertir span a enteros y clampear
+        int startX = max(0, int(floor(rowMinX)));
+        int endX   = min(hybridCst.screenWidth - 1, int(ceil(rowMaxX)));
 
-            for (int i = 1; i < intersections; ++i) 
-            {
-                xMin = fminf(xMin, xIntersections[i]);
-                xMax = fmaxf(xMax, xIntersections[i]);
-            }
+        if (startX <= endX)
+        {
+
             glm::vec3 rayColStart = hybridCst.rayStart + (float)py * hybridCst.dy;
-            for (int px = max(0, __float2int_ru(xMin)); px <= min(__float2int_rd(xMax), hybridCst.screenWidth -1); ++px)
+            for (int px = max(0, startX); px <= min(endX, hybridCst.screenWidth -1); ++px)
             {
-                glm::vec3 rd = computeRayDirection(px, py, fovTan, halfFovTan);
+                glm::vec3 ray = rayColStart + (float)px * hybridCst.dx;
+                glm::vec3 rd = fastNormalize(ray.x * hybridCst.right + ray.y * hybridCst.up - ray.z * hybridCst.front);
                 glm::vec4 tnor = iCylinder(glm::vec3(hybridCst.cameraPos), rd, pa, pb, radius);
                 int index = px + hybridCst.screenWidth*py;
 
                 if (tnor.x > 0.0f) {
                     float t = tnor.x;
-                    glm::vec3 hit = (rayColStart + (float)px * hybridCst.dx) * t;
+                    glm::vec3 hit = ray * t;
                     float depth = __fdividef(fmaf(hit.z, hybridCst.proj[2][2], hybridCst.proj[3][2]), -hit.z);
 
                     unsigned int depthU = __float_as_uint(depth);
@@ -301,8 +301,8 @@ __global__ void smallCylinderRasterKernel(
                     // if we won (old > depth)
                     if (__uint_as_float(old) > depth) {
                         // own the pixel
-                        glm::vec3 normal = glm::normalize(glm::vec3(tnor.y, tnor.z, tnor.w));
-                        float lambert = glm::max(0.0f, glm::dot(normal, -glm::normalize(rd * t)));
+                        glm::vec3 normal = fastNormalize(glm::vec3(tnor.y, tnor.z, tnor.w));
+                        float lambert = fmaxf(0.0f, glm::dot(normal, -rd));
                         glm::vec3 color = glm::vec3(bondsColor[0], bondsColor[1], bondsColor[2]) * lambert * diffuse;
                         uchar4 ucharColor = make_uchar4(
                             (unsigned char)(color.x * 255.0f),

--- a/kernels/hybrid_binning/small_entity_raster.cu
+++ b/kernels/hybrid_binning/small_entity_raster.cu
@@ -12,6 +12,17 @@
 
 extern __constant__ HybridConstants hybridCst;
 
+__constant__ float atomsColor[3] = {0.8f, 0.1f, 0.1f};
+__constant__ float bondsColor[3] = {0.2f, 0.5f, 0.9f};
+__constant__ float diffuse = 0.9f;
+
+__device__ inline float intersectX(glm::vec2 a, glm::vec2 b, float y) 
+{
+    if (a.y == b.y) return a.x; // horizontal line
+    float t = __fdividef(y - a.y, b.y - a.y);
+    return fmaf(t, (b.x - a.x), a.x);
+}
+
 __device__ inline float iSphere(const glm::vec3& ro, const glm::vec3& rd,
                                 const glm::vec3& center, float radius) {
     glm::vec3 oc = ro - center;
@@ -22,22 +33,30 @@ __device__ inline float iSphere(const glm::vec3& ro, const glm::vec3& rd,
     return -b - sqrtf(h);
 }
 
-__device__ inline glm::vec2 iCylinder(const glm::vec3& ro, const glm::vec3& rd,
+__device__ inline glm::vec4 iCylinder(const glm::vec3& ro, const glm::vec3& rd,
                                       const glm::vec3& pa, const glm::vec3& pb, float ra) {
     glm::vec3 ba = pb - pa, oc = ro - pa;
     float baba = glm::dot(ba, ba), bard = glm::dot(ba, rd), baoc = glm::dot(ba, oc);
-    float k2 = baba - bard * bard;
-    float k1 = baba * glm::dot(oc, rd) - baoc * bard;
-    float k0 = baba * glm::dot(oc, oc) - baoc * baoc - ra * ra * baba;
-    float h = k1 * k1 - k2 * k0;
-    if (h < 0.0f) return glm::vec2(-1.0f);
+    
+    float k2 = fmaf(bard, -bard, baba);
+    float k1 = fmaf(glm::dot(oc,rd), baba, -baoc*bard);
+    float k0 = fmaf(baba, glm::dot(oc,oc), fmaf(- ra*ra, baba, -baoc*baoc));
+    
+    float h = fmaf(k1, k1, -k2*k0);
+    if (h < 0.0f) return glm::vec4(-1.0f);
+
     h = sqrtf(h);
-    float t = (-k1 - h) / k2;
-    float y = baoc + t * bard;
-    if (y > 0.0f && y < baba) return glm::vec2(t, y / baba);
-    t = ((y < 0.0f ? 0.0f : baba) - baoc) / bard;
-    if (fabsf(k1 + k2 * t) < h) return glm::vec2(t, y < 0.0f ? 0.0f : 1.0f);
-    return glm::vec2(-1.0f);
+    float t =  __fdividef(-k1-h, k2);
+
+    // body
+    float y = fmaf(t, bard, baoc);
+    if( y>0.0f && y<baba ) return glm::vec4( t, oc+t*rd - ba*y/baba );
+    
+    // caps
+    // t = ( ((y<0.0f) ? 0.0f : baba) - baoc)/bard;
+    // if( abs(k1+k2*t)<h ) return vec4( t, ba*sign(y)/sqrt(baba) );
+
+    return glm::vec4(-1.0f);
 }
 
 __device__ inline glm::vec3 computeRayDirection(int px, int py, float fovTan, float halfFovTan) {
@@ -55,58 +74,80 @@ __global__ void smallSphereRasterKernel(
 {
     unsigned int idx = blockIdx.x * blockDim.x + threadIdx.x;
     if (idx >= smallSphereCount) return;
+
     unsigned int sphereIdx = smallSphereIndices[idx];
+
     glm::vec4 spherePosR = spheres[sphereIdx];
     glm::vec3 spherePos = glm::vec3(spherePosR);
     float radius = spherePosR.w;
+
     glm::vec4 camSpace4 = hybridCst.view * glm::vec4(spherePos, 1.0f);
     glm::vec3 cameraSpaceSphere = glm::vec3(camSpace4);
     glm::vec3 normCamSpaceSphere = glm::normalize(cameraSpaceSphere);
     glm::vec3 camImposPos = cameraSpaceSphere - normCamSpaceSphere * radius;
+
     float dist = glm::length(cameraSpaceSphere) + 1e-6f;
-    float sinAngle = radius / dist;
-    float tanAngle = tanf(asinf(fminf(sinAngle, 0.999f)));
+    float sinAngle = __fdividef(radius, dist);
+    float tanAngle = tanf(asinf(sinAngle));
     float quadScale = tanAngle * glm::length(camImposPos);
+
     glm::vec3 upVec(0.0f, 1.0f, 0.0f);
     glm::vec3 impU = glm::normalize(glm::cross(normCamSpaceSphere, upVec));
-    if (glm::length(impU) < 0.001f) impU = glm::vec3(1.0f, 0.0f, 0.0f);
     glm::vec3 impV = glm::cross(impU, normCamSpaceSphere) * quadScale;
     impU *= quadScale;
+
     glm::vec3 corners[4] = {
         camImposPos + impU + impV, camImposPos - impU + impV,
         camImposPos + impU - impV, camImposPos - impU - impV
     };
+
     glm::vec2 minC(1e6f), maxC(-1e6f);
+    #pragma unroll
     for (int i = 0; i < 4; i++) {
         glm::vec4 clip = hybridCst.proj * glm::vec4(corners[i], 1.0f);
-        float iw = 1.0f / clip.w;
-        minC.x = fminf(minC.x, clip.x * iw); minC.y = fminf(minC.y, clip.y * iw);
-        maxC.x = fmaxf(maxC.x, clip.x * iw); maxC.y = fmaxf(maxC.y, clip.y * iw);
+        float iw = __fdividef(1.0f, clip.w);
+        float x = clip.x * iw;
+        float y = clip.y * iw;
+        minC.x = fminf(minC.x, x); minC.y = fminf(minC.y, y);
+        maxC.x = fmaxf(maxC.x, x); maxC.y = fmaxf(maxC.y, y);
     }
-    int screenMinX = max(0, (int)floorf((minC.x * 0.5f + 0.5f) * hybridCst.screenWidth));
-    int screenMinY = max(0, (int)floorf((minC.y * 0.5f + 0.5f) * hybridCst.screenHeight));
-    int screenMaxX = min(hybridCst.screenWidth, (int)ceilf((maxC.x * 0.5f + 0.5f) * hybridCst.screenWidth));
-    int screenMaxY = min(hybridCst.screenHeight, (int)ceilf((maxC.y * 0.5f + 0.5f) * hybridCst.screenHeight));
-    float aspectRatio = (float)hybridCst.screenWidth / (float)hybridCst.screenHeight;
+
+    int screenMinX = __float2int_rd(fmaf(minC.x, 0.5f, 0.5f) * hybridCst.screenWidth);
+    int screenMinY = __float2int_rd(fmaf(minC.y, 0.5f, 0.5f) * hybridCst.screenHeight);
+    int screenMaxX = __float2int_ru(fmaf(maxC.x, 0.5f, 0.5f) * hybridCst.screenWidth);
+    int screenMaxY = __float2int_ru(fmaf(maxC.y, 0.5f, 0.5f) * hybridCst.screenHeight);
+
+
+    float difx = float(screenMaxX - screenMinX);
+    float dify = float(screenMaxY - screenMinY);
+    if (difx * dify <= 2.0f) return;
+
+    float aspectRatio = __fdividef(float(hybridCst.screenWidth), float(hybridCst.screenHeight));
     float fovRad = glm::radians(hybridCst.fov);
-    float fovTan = tanf(fovRad * 0.5f);
+    float fovTan = __tanf(fovRad * 0.5f);
     float halfFovTan = fovTan * aspectRatio;
+
+
+    float proj22 = hybridCst.proj[2][2];
+    float proj32 = hybridCst.proj[3][2];
+
     for (int py = screenMinY; py < screenMaxY; py++) {
         for (int px = screenMinX; px < screenMaxX; px++) {
             glm::vec3 rd = computeRayDirection(px, py, fovTan, halfFovTan);
             float t = iSphere(hybridCst.cameraPos, rd, spherePos, radius);
+
             if (t > 0.0f) {
                 glm::vec3 hit = hybridCst.cameraPos + rd * t;
-                glm::vec4 hitClip = hybridCst.proj * (hybridCst.view * glm::vec4(hit, 1.0f));
-                float depth = hitClip.z / hitClip.w;
+                float depth = __fdividef(fmaf(hit.z, proj22, proj32), -hit.z);
                 unsigned int depthU = __float_as_uint(depth);
+
                 int pixelIdx = py * hybridCst.screenWidth + px;
                 if (atomicMin(&depthBuffer[pixelIdx], depthU) != depthU) {
-                    glm::vec3 normal = glm::normalize(hit - spherePos);
-                    float lambert = fmaxf(0.0f, glm::dot(normal, -glm::normalize(rd)));
-                    glm::vec3 color = glm::vec3(0.01f, 1.0f, 0.05f) * lambert * 0.9f;
-                    uchar4 pixel = make_uchar4((unsigned char)(color.x * 255.0f), (unsigned char)(color.y * 255.0f), (unsigned char)(color.z * 255.0f), 255);
-                    surf2Dwrite(pixel, outputImage, px * sizeof(uchar4), py);
+                    glm::vec3 normal = glm::normalize(hybridCst.cameraPos + rd * t - glm::vec3(spherePosR));
+                    float lambert = fmaxf(0.0f, glm::dot(normal, -glm::normalize(rd*t)));
+                    glm::vec3 color = glm::vec3(atomsColor[0], atomsColor[1], atomsColor[2]) * lambert * diffuse;
+                    uchar4 ucharColor = make_uchar4(color.x*255, color.y*255, color.z*255, 255);
+                    surf2Dwrite(ucharColor, outputImage, px * sizeof(uchar4), py);
                 }
             }
         }
@@ -128,46 +169,141 @@ __global__ void smallCylinderRasterKernel(
     float radius = cyl.pa_r.w;
     glm::vec4 camA = hybridCst.view * glm::vec4(pa, 1.0f);
     glm::vec4 camB = hybridCst.view * glm::vec4(pb, 1.0f);
-    glm::vec3 axis = glm::vec3(camB) - glm::vec3(camA);
-    float axisLenSq = glm::dot(axis, axis);
-    glm::vec3 e = radius * glm::sqrt(glm::max(glm::vec3(0.001f), glm::vec3(1.0f) - axis * axis / axisLenSq));
-    glm::vec3 pts[4] = { glm::vec3(camA) + e, glm::vec3(camA) - e, glm::vec3(camB) + e, glm::vec3(camB) - e };
-    glm::vec2 minC(1e6f), maxC(-1e6f);
-    for (int i = 0; i < 4; i++) {
-        glm::vec4 clip = hybridCst.proj * glm::vec4(pts[i], 1.0f);
-        if (clip.w > 0.001f) {
-            float iw = 1.0f / clip.w;
-            minC.x = fminf(minC.x, clip.x * iw); minC.y = fminf(minC.y, clip.y * iw);
-            maxC.x = fmaxf(maxC.x, clip.x * iw); maxC.y = fmaxf(maxC.y, clip.y * iw);
-        }
+    glm::vec3 camImpPosA, camImpPosB;
+    if ( camA.z < camB.z )
+	{
+		camImpPosA = glm::vec3(camB);
+		camImpPosB = glm::vec3(camA);
+	}
+	else
+	{
+		camImpPosA = glm::vec3(camA);
+		camImpPosB = glm::vec3(camB);
+	}
+    glm::vec3 center = glm::normalize( ( camImpPosA + camImpPosB ) * 0.5f );
+    glm::vec2 projectedPoints[4];
+    // Cylinder axis
+    const glm::vec3 z = glm::normalize(camImpPosB - camImpPosA);
+
+    // Find orthonormal x,y axes orthogonal to cylinder axis
+    glm::vec3 x = glm::normalize(glm::cross(center, z));
+    glm::vec3 y = glm::normalize(glm::cross(x, z)); // make full basis
+
+    // Compute impostor construction vectors.
+    const float dV0 = glm::length( camImpPosA );
+    const float dV1 = glm::length( camImpPosB );
+
+    const float sinAngle = __fdividef(radius, dV0);
+    float		angle	 = asinf( sinAngle );
+    const glm::vec3	y1		 = y * radius;
+    const glm::vec3	x2		 = x * radius * cosf( angle );
+    const glm::vec3	y2		 = y1 * sinAngle;
+    angle				 = asinf( __fdividef(radius, dV1) );
+    const glm::vec3 x3		 = x * ( dV1 - radius ) * __tanf( angle );
+
+    // Compute impostors vertices.
+    const glm::vec3 v1 = camImpPosA - x2 + y2;
+    const glm::vec3 v2 = camImpPosA + x2 + y2;
+    const glm::vec3 v3 = camImpPosB - x3 + y1;
+    const glm::vec3 v4 = camImpPosB + x3 + y1;
+
+    const glm::vec4 v1Proj = hybridCst.proj * glm::vec4(v1, 1.0f);
+    const glm::vec4 v2Proj = hybridCst.proj * glm::vec4(v2, 1.0f);
+    const glm::vec4 v3Proj = hybridCst.proj * glm::vec4(v3, 1.0f);
+    const glm::vec4 v4Proj = hybridCst.proj * glm::vec4(v4, 1.0f);
+
+    glm::vec3 ndcv1Proj = glm::vec3(__fdividef(v1Proj.x, v1Proj.w), __fdividef(v1Proj.y, v1Proj.w), __fdividef(v1Proj.z, v1Proj.w));
+    glm::vec3 ndcv2Proj = glm::vec3(__fdividef(v2Proj.x, v2Proj.w), __fdividef(v2Proj.y, v2Proj.w), __fdividef(v2Proj.z, v2Proj.w));
+    glm::vec3 ndcv3Proj = glm::vec3(__fdividef(v3Proj.x, v3Proj.w), __fdividef(v3Proj.y, v3Proj.w), __fdividef(v3Proj.z, v3Proj.w));
+    glm::vec3 ndcv4Proj = glm::vec3(__fdividef(v4Proj.x, v4Proj.w), __fdividef(v4Proj.y, v4Proj.w), __fdividef(v4Proj.z, v4Proj.w));
+
+    projectedPoints[0] = glm::vec2(ndcv1Proj);
+    projectedPoints[1] = glm::vec2(ndcv2Proj);
+    projectedPoints[2] = glm::vec2(ndcv4Proj);
+    projectedPoints[3] = glm::vec2(ndcv3Proj);
+
+    int minX = hybridCst.screenWidth;
+    int maxX = 0;
+    int minY = hybridCst.screenHeight;
+    int maxY = 0;
+
+    #pragma unroll 4
+    for (int i = 0; i < 4; i++) 
+    {
+        projectedPoints[i].x = int(fmaf(projectedPoints[i].x, 0.5f, 0.5f) * hybridCst.screenWidth);
+        projectedPoints[i].y = int(fmaf(projectedPoints[i].y, 0.5f, 0.5f) * hybridCst.screenHeight);
+
+        minY = min(minY, __float2int_rd(projectedPoints[i].y)); 
+        maxY = max(maxY, __float2int_ru(projectedPoints[i].y));
+        minX = min(minX, __float2int_rd(projectedPoints[i].x)); 
+        maxX = max(maxX, __float2int_ru(projectedPoints[i].x));
     }
-    int screenMinX = max(0, (int)floorf((minC.x * 0.5f + 0.5f) * hybridCst.screenWidth));
-    int screenMinY = max(0, (int)floorf((minC.y * 0.5f + 0.5f) * hybridCst.screenHeight));
-    int screenMaxX = min(hybridCst.screenWidth, (int)ceilf((maxC.x * 0.5f + 0.5f) * hybridCst.screenWidth));
-    int screenMaxY = min(hybridCst.screenHeight, (int)ceilf((maxC.y * 0.5f + 0.5f) * hybridCst.screenHeight));
-    float aspectRatio = (float)hybridCst.screenWidth / (float)hybridCst.screenHeight;
+
+    if (maxY < 0 || minY >= hybridCst.screenHeight || maxY - minY < 2 ||
+        maxX < 0 || minX >= hybridCst.screenWidth || maxX - minX < 2) return;
+    
+
+    float aspectRatio = fdividef(hybridCst.screenWidth, hybridCst.screenHeight);
     float fovRad = glm::radians(hybridCst.fov);
-    float fovTan = tanf(fovRad * 0.5f);
+    float fovTan = __tanf(fovRad * 0.5f);
     float halfFovTan = fovTan * aspectRatio;
-    for (int py = screenMinY; py < screenMaxY; py++) {
-        for (int px = screenMinX; px < screenMaxX; px++) {
-            glm::vec3 rd = computeRayDirection(px, py, fovTan, halfFovTan);
-            glm::vec2 result = iCylinder(hybridCst.cameraPos, rd, pa, pb, radius);
-            if (result.x > 0.0f) {
-                glm::vec3 hit = hybridCst.cameraPos + rd * result.x;
-                glm::vec4 hitClip = hybridCst.proj * (hybridCst.view * glm::vec4(hit, 1.0f));
-                float depth = hitClip.z / hitClip.w;
-                unsigned int depthU = __float_as_uint(depth);
-                int pixelIdx = py * hybridCst.screenWidth + px;
-                if (atomicMin(&depthBuffer[pixelIdx], depthU) != depthU) {
-                    glm::vec3 ba = pb - pa, hitLocal = hit - pa;
-                    float h = glm::dot(hitLocal, ba) / glm::dot(ba, ba);
-                    glm::vec3 normal = glm::normalize(hitLocal - ba * glm::clamp(h, 0.0f, 1.0f));
-                    float lambert = fmaxf(0.0f, glm::dot(normal, -glm::normalize(rd)));
-                    glm::vec3 color = glm::vec3(0.01f, 1.0f, 0.05f) * lambert * 0.9f;
-                    uchar4 pixel = make_uchar4((unsigned char)(color.x * 255.0f), (unsigned char)(color.y * 255.0f), (unsigned char)(color.z * 255.0f), 255);
-                    surf2Dwrite(pixel, outputImage, px * sizeof(uchar4), py);
-                }
+
+    for (int py = fminf(hybridCst.screenHeight-1, maxY); py >= fmaxf(0, minY); --py)
+    {
+        float xIntersections[4];
+        int intersections = 0;
+
+        #pragma unroll 4
+        for (int i = 0; i < 4; ++i) 
+        {
+            const glm::vec2 a = projectedPoints[i];
+            const glm::vec2 b = projectedPoints[(i + 1) % 4];
+
+            if ((py >= a.y && py <= b.y) || (py >= b.y && py <= a.y)) 
+            {
+                float x = intersectX(a, b, py);
+                xIntersections[intersections] = x;
+                intersections++;
+            }
+        }
+
+        if (intersections >= 2)
+        {
+            float xMin = xIntersections[0];
+            float xMax = xIntersections[0];
+
+            for (int i = 1; i < intersections; ++i) 
+            {
+                xMin = fminf(xMin, xIntersections[i]);
+                xMax = fmaxf(xMax, xIntersections[i]);
+            }
+
+            for (int px = fmaxf(0, __float2int_ru(xMin)); px <= fminf(__float2int_rd(xMax), hybridCst.screenWidth -1); ++px)
+            {
+                glm::vec3 rd = computeRayDirection(px, py, fovTan, halfFovTan);
+                glm::vec4 tnor = iCylinder(glm::vec3(hybridCst.cameraPos), rd, pa, pb, radius);
+                int index = px + hybridCst.screenWidth*py;
+
+                if (tnor.x > 0.0f) {
+                    float t = tnor.x;
+                    glm::vec3 hit = hybridCst.cameraPos + rd * t;
+                    float depth = __fdividef(fmaf(hit.z, hybridCst.proj[2][2], hybridCst.proj[3][2]), -hit.z);
+
+                    unsigned int depthU = __float_as_uint(depth);
+                    
+                    // atomicMin over uint bits (we store depth as float bits in uint)
+                    unsigned int old = atomicMin(&depthBuffer[index], depthU);
+
+                    // if we won (old > depth)
+                    if (__uint_as_float(old) > depth) {
+                        // own the pixel
+                        glm::vec3 normal = glm::normalize(glm::vec3(tnor.y, tnor.z, tnor.w));
+                        float lambert = glm::max(0.0f, glm::dot(normal, -glm::normalize(rd * t)));
+                        glm::vec3 color = glm::vec3(bondsColor[0], bondsColor[1], bondsColor[2]) * lambert * diffuse;
+                        uchar4 ucharColor = make_uchar4(color.x*255, color.y*255, color.z*255, 255);
+                        surf2Dwrite(ucharColor, outputImage, px * sizeof(uchar4), py); 
+                    }
+                } 
             }
         }
     }

--- a/kernels/hybrid_binning/small_entity_raster.cu
+++ b/kernels/hybrid_binning/small_entity_raster.cu
@@ -88,11 +88,12 @@ __global__ void smallSphereRasterKernel(
 
     float dist = glm::length(cameraSpaceSphere) + 1e-6f;
     float sinAngle = __fdividef(radius, dist);
-    float tanAngle = tanf(asinf(sinAngle));
+    float tanAngle = tanf(asinf(fminf(sinAngle, 0.999f)));
     float quadScale = tanAngle * glm::length(camImposPos);
 
     glm::vec3 upVec(0.0f, 1.0f, 0.0f);
     glm::vec3 impU = glm::normalize(glm::cross(normCamSpaceSphere, upVec));
+    if (glm::length(impU) < 0.001f) impU = glm::vec3(1.0f, 0.0f, 0.0f);
     glm::vec3 impV = glm::cross(impU, normCamSpaceSphere) * quadScale;
     impU *= quadScale;
 
@@ -112,10 +113,10 @@ __global__ void smallSphereRasterKernel(
         maxC.x = fmaxf(maxC.x, x); maxC.y = fmaxf(maxC.y, y);
     }
 
-    int screenMinX = __float2int_rd(fmaf(minC.x, 0.5f, 0.5f) * hybridCst.screenWidth);
-    int screenMinY = __float2int_rd(fmaf(minC.y, 0.5f, 0.5f) * hybridCst.screenHeight);
-    int screenMaxX = __float2int_ru(fmaf(maxC.x, 0.5f, 0.5f) * hybridCst.screenWidth);
-    int screenMaxY = __float2int_ru(fmaf(maxC.y, 0.5f, 0.5f) * hybridCst.screenHeight);
+    int screenMinX = max(0, __float2int_rd(fmaf(minC.x, 0.5f, 0.5f) * hybridCst.screenWidth));
+    int screenMinY = max(0, __float2int_rd(fmaf(minC.y, 0.5f, 0.5f) * hybridCst.screenHeight));
+    int screenMaxX = min(hybridCst.screenWidth,  __float2int_ru(fmaf(maxC.x, 0.5f, 0.5f) * hybridCst.screenWidth));
+    int screenMaxY = min(hybridCst.screenHeight, __float2int_ru(fmaf(maxC.y, 0.5f, 0.5f) * hybridCst.screenHeight));
 
 
     float difx = float(screenMaxX - screenMinX);
@@ -132,21 +133,26 @@ __global__ void smallSphereRasterKernel(
     float proj32 = hybridCst.proj[3][2];
 
     for (int py = screenMinY; py < screenMaxY; py++) {
+        glm::vec3 rayColStart = hybridCst.rayStart + (float)py * hybridCst.dy;
         for (int px = screenMinX; px < screenMaxX; px++) {
             glm::vec3 rd = computeRayDirection(px, py, fovTan, halfFovTan);
             float t = iSphere(hybridCst.cameraPos, rd, spherePos, radius);
 
             if (t > 0.0f) {
-                glm::vec3 hit = hybridCst.cameraPos + rd * t;
+                glm::vec3 hit = (rayColStart + (float)px * hybridCst.dx) * t;
                 float depth = __fdividef(fmaf(hit.z, proj22, proj32), -hit.z);
                 unsigned int depthU = __float_as_uint(depth);
 
                 int pixelIdx = py * hybridCst.screenWidth + px;
-                if (atomicMin(&depthBuffer[pixelIdx], depthU) != depthU) {
+                unsigned int old = atomicMin(&depthBuffer[pixelIdx], depthU);
+                if (__uint_as_float(old) > depth) {
                     glm::vec3 normal = glm::normalize(hybridCst.cameraPos + rd * t - glm::vec3(spherePosR));
-                    float lambert = fmaxf(0.0f, glm::dot(normal, -glm::normalize(rd*t)));
+                    float lambert = fmaxf(0.0f, glm::dot(normal, -glm::normalize(rd * t)));
                     glm::vec3 color = glm::vec3(atomsColor[0], atomsColor[1], atomsColor[2]) * lambert * diffuse;
-                    uchar4 ucharColor = make_uchar4(color.x*255, color.y*255, color.z*255, 255);
+                    uchar4 ucharColor = make_uchar4(
+                        (unsigned char)(color.x * 255.0f),
+                        (unsigned char)(color.y * 255.0f),
+                        (unsigned char)(color.z * 255.0f), 255);
                     surf2Dwrite(ucharColor, outputImage, px * sizeof(uchar4), py);
                 }
             }
@@ -277,7 +283,7 @@ __global__ void smallCylinderRasterKernel(
                 xMin = fminf(xMin, xIntersections[i]);
                 xMax = fmaxf(xMax, xIntersections[i]);
             }
-
+            glm::vec3 rayColStart = hybridCst.rayStart + (float)py * hybridCst.dy;
             for (int px = fmaxf(0, __float2int_ru(xMin)); px <= fminf(__float2int_rd(xMax), hybridCst.screenWidth -1); ++px)
             {
                 glm::vec3 rd = computeRayDirection(px, py, fovTan, halfFovTan);
@@ -286,7 +292,7 @@ __global__ void smallCylinderRasterKernel(
 
                 if (tnor.x > 0.0f) {
                     float t = tnor.x;
-                    glm::vec3 hit = hybridCst.cameraPos + rd * t;
+                    glm::vec3 hit = (rayColStart + (float)px * hybridCst.dx) * t;
                     float depth = __fdividef(fmaf(hit.z, hybridCst.proj[2][2], hybridCst.proj[3][2]), -hit.z);
 
                     unsigned int depthU = __float_as_uint(depth);
@@ -300,7 +306,10 @@ __global__ void smallCylinderRasterKernel(
                         glm::vec3 normal = glm::normalize(glm::vec3(tnor.y, tnor.z, tnor.w));
                         float lambert = glm::max(0.0f, glm::dot(normal, -glm::normalize(rd * t)));
                         glm::vec3 color = glm::vec3(bondsColor[0], bondsColor[1], bondsColor[2]) * lambert * diffuse;
-                        uchar4 ucharColor = make_uchar4(color.x*255, color.y*255, color.z*255, 255);
+                        uchar4 ucharColor = make_uchar4(
+                            (unsigned char)(color.x * 255.0f),
+                            (unsigned char)(color.y * 255.0f),
+                            (unsigned char)(color.z * 255.0f), 255);
                         surf2Dwrite(ucharColor, outputImage, px * sizeof(uchar4), py); 
                     }
                 } 

--- a/kernels/hybrid_binning/sort_and_rle.cu
+++ b/kernels/hybrid_binning/sort_and_rle.cu
@@ -2,11 +2,80 @@
  * @file sort_and_rle.cu
  * @brief CUB DeviceRadixSort::SortPairs + DeviceRunLengthEncode to build tile offsets.
  * Sort pairs by TileID; RLE on sorted keys; build tileOffsets[0..totalTiles] from RLE output.
+ * Also supports 64-bit (tile_id, entity_id) pairs: sort by tile_id (high 32 bits), RLE, extract entity indices.
  */
 
 #include <cuda_runtime.h>
 #include <device_launch_parameters.h>
+#include <cstdint>
 #include <cub/cub.cuh>
+
+// ---- 64-bit pair path: d_pairs = (tile_id << 32) | entity_id ----
+
+__global__ void extractKeysFromPairs64Kernel(
+    const unsigned long long* __restrict__ d_pairs,
+    unsigned int* __restrict__ d_keys,
+    unsigned int num_pairs)
+{
+    unsigned int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < num_pairs)
+        d_keys[i] = (unsigned int)(d_pairs[i] >> 32);
+}
+
+/** Sort 64-bit pairs (tile_id in high 32 bits), run RLE on tile_id, build tile offsets. Entity index = low 32 bits, extracted in tiled raster. */
+extern "C" void sortPairs64AndBuildTileOffsets(
+    unsigned long long* d_pairs_in,
+    unsigned long long* d_pairs_out,
+    unsigned int num_pairs,
+    unsigned int total_tiles,
+    unsigned int* d_keys_extract,      /* temp: size num_pairs, holds tile_id per element for RLE input */
+    unsigned int* d_tile_offsets,
+    unsigned int* d_unique_out,
+    unsigned int* d_counts_out,
+    unsigned int* d_run_offsets,
+    unsigned int* d_num_runs,
+    void* d_temp_storage_sort64,
+    size_t temp_storage_bytes_sort64,
+    void* d_temp_storage_rle,
+    size_t temp_storage_bytes_rle,
+    void* d_temp_storage_scan,
+    size_t temp_storage_bytes_scan,
+    cudaStream_t stream)
+{
+    if (num_pairs == 0) {
+        cudaMemsetAsync(d_tile_offsets, 0, (total_tiles + 1) * sizeof(unsigned int), stream);
+        return;
+    }
+
+    // 1) Radix sort 64-bit pairs (sorts by full key: tile_id in high 32 bits, then entity_id)
+    cub::DeviceRadixSort::SortKeys(
+        d_temp_storage_sort64,
+        temp_storage_bytes_sort64,
+        d_pairs_in,
+        d_pairs_out,
+        num_pairs,
+        0, 64,
+        stream);
+
+    // 2) Extract tile_id (high 32 bits) for RLE
+    extractKeysFromPairs64Kernel<<<(num_pairs + 255) / 256, 256, 0, stream>>>(d_pairs_out, d_keys_extract, num_pairs);
+
+    // 3) Run-length encode on tile ids
+    cub::DeviceRunLengthEncode::Encode(
+        d_temp_storage_rle,
+        temp_storage_bytes_rle,
+        d_keys_extract,
+        d_unique_out,
+        d_counts_out,
+        d_num_runs,
+        num_pairs,
+        stream);
+
+    // Caller must: cudaStreamSynchronize, cudaMemcpy d_num_runs to get num_runs, then:
+    // buildTileOffsetsFromRLE(..., num_runs, ...)  // does ExclusiveSum on d_counts_out -> d_run_offsets
+    // launchScatterAndFillTileOffsets(...)
+    // Tiled raster reads d_pairs_out and extracts entity_id = pair & 0xFFFFFFFFu per element.
+}
 
 // Sort: keys/values in -> keys/values out (separate buffers)
 extern "C" void sortPairsAndBuildTileOffsets(
@@ -103,7 +172,8 @@ __global__ void scatterTileOffsetsKernel(
 {
     for (unsigned int i = threadIdx.x + blockIdx.x * blockDim.x; i < num_runs; i += blockDim.x * gridDim.x) {
         unsigned int t = d_unique_tile_ids[i];
-        tileOffsets[t] = d_run_offsets[i];
+        if (t < total_tiles)
+            tileOffsets[t] = d_run_offsets[i];
     }
     if (blockIdx.x == 0 && threadIdx.x == 0) {
         tileOffsets[total_tiles] = num_pairs;

--- a/kernels/hybrid_binning/sort_and_rle.cu
+++ b/kernels/hybrid_binning/sort_and_rle.cu
@@ -1,0 +1,140 @@
+/**
+ * @file sort_and_rle.cu
+ * @brief CUB DeviceRadixSort::SortPairs + DeviceRunLengthEncode to build tile offsets.
+ * Sort pairs by TileID; RLE on sorted keys; build tileOffsets[0..totalTiles] from RLE output.
+ */
+
+#include <cuda_runtime.h>
+#include <device_launch_parameters.h>
+#include <cub/cub.cuh>
+
+// Sort: keys/values in -> keys/values out (separate buffers)
+extern "C" void sortPairsAndBuildTileOffsets(
+    unsigned int* d_keys_in,
+    unsigned int* d_values_in,
+    unsigned int* d_keys_out,
+    unsigned int* d_values_out,
+    unsigned int num_pairs,
+    unsigned int total_tiles,
+    unsigned int* d_tile_offsets,
+    unsigned int* d_unique_out,
+    unsigned int* d_counts_out,
+    unsigned int* d_run_offsets,
+    unsigned int* d_num_runs,
+    void* d_temp_storage_sort,
+    size_t temp_storage_bytes_sort,
+    void* d_temp_storage_rle,
+    size_t temp_storage_bytes_rle,
+    void* d_temp_storage_scan,
+    size_t temp_storage_bytes_scan,
+    cudaStream_t stream)
+{
+    if (num_pairs == 0) {
+        cudaMemsetAsync(d_tile_offsets, 0, (total_tiles + 1) * sizeof(unsigned int), stream);
+        return;
+    }
+
+    // 1) Sort pairs by key (TileID): in -> out
+    cub::DeviceRadixSort::SortPairs(
+        d_temp_storage_sort,
+        temp_storage_bytes_sort,
+        d_keys_in,
+        d_keys_out,
+        d_values_in,
+        d_values_out,
+        num_pairs,
+        0, 32,
+        stream);
+
+    // 2) Run-length encode on sorted keys
+    cub::DeviceRunLengthEncode::Encode(
+        d_temp_storage_rle,
+        temp_storage_bytes_rle,
+        d_keys_out,
+        d_unique_out,
+        d_counts_out,
+        d_num_runs,
+        num_pairs,
+        stream);
+
+    // Caller must: cudaStreamSynchronize(stream), then cudaMemcpy from d_num_runs to get num_runs,
+    // then call buildTileOffsetsFromRLE and launchScatterAndFillTileOffsets.
+}
+
+extern "C" void buildTileOffsetsFromRLE(
+    const unsigned int* d_unique_out,
+    const unsigned int* d_counts_out,
+    unsigned int num_runs,
+    unsigned int num_pairs,
+    unsigned int total_tiles,
+    unsigned int* d_run_offsets,     // exclusive sum of d_counts_out, computed here
+    unsigned int* d_tile_offsets,
+    void* d_temp_storage_scan,
+    size_t temp_storage_bytes_scan,
+    cudaStream_t stream)
+{
+    if (num_pairs == 0) {
+        cudaMemsetAsync(d_tile_offsets, 0, (total_tiles + 1) * sizeof(unsigned int), stream);
+        return;
+    }
+
+    // Exclusive sum of run lengths -> run_offsets
+    cub::DeviceScan::ExclusiveSum(
+        d_temp_storage_scan,
+        temp_storage_bytes_scan,
+        d_counts_out,
+        d_run_offsets,
+        num_runs,
+        stream);
+
+    // Scatter: tileOffsets[unique_out[i]] = run_offsets[i], and tileOffsets[total_tiles] = num_pairs
+    // Then fill gaps. We do this in a kernel.
+    cudaMemsetAsync(d_tile_offsets, 0xFF, (total_tiles + 1) * sizeof(unsigned int), stream);
+}
+
+// Kernel: scatter run_offsets into tileOffsets, set tileOffsets[total_tiles]=num_pairs
+__global__ void scatterTileOffsetsKernel(
+    const unsigned int* __restrict__ d_unique_tile_ids,
+    const unsigned int* __restrict__ d_run_offsets,
+    unsigned int num_runs,
+    unsigned int num_pairs,
+    unsigned int total_tiles,
+    unsigned int* __restrict__ tileOffsets)
+{
+    for (unsigned int i = threadIdx.x + blockIdx.x * blockDim.x; i < num_runs; i += blockDim.x * gridDim.x) {
+        unsigned int t = d_unique_tile_ids[i];
+        tileOffsets[t] = d_run_offsets[i];
+    }
+    if (blockIdx.x == 0 && threadIdx.x == 0) {
+        tileOffsets[total_tiles] = num_pairs;
+    }
+}
+
+// Kernel: fill gaps (tiles with no entities). Single-thread sequential pass so propagation is correct.
+__global__ void fillTileOffsetsGapsKernel(
+    unsigned int total_tiles,
+    unsigned int* __restrict__ tileOffsets)
+{
+    if (threadIdx.x != 0 || blockIdx.x != 0) return;
+    unsigned int last = 0u;
+    for (unsigned int t = 0; t < total_tiles; ++t) {
+        if (tileOffsets[t] != 0xFFFFFFFFu)
+            last = tileOffsets[t];
+        else
+            tileOffsets[t] = last;
+    }
+}
+
+extern "C" void launchScatterAndFillTileOffsets(
+    const unsigned int* d_unique_out,
+    const unsigned int* d_run_offsets,
+    unsigned int num_runs,
+    unsigned int num_pairs,
+    unsigned int total_tiles,
+    unsigned int* d_tile_offsets,
+    cudaStream_t stream)
+{
+    scatterTileOffsetsKernel<<<(num_runs + 255) / 256, 256, 0, stream>>>(
+        d_unique_out, d_run_offsets, num_runs, num_pairs, total_tiles, d_tile_offsets);
+    fillTileOffsetsGapsKernel<<<1, 1, 0, stream>>>(total_tiles, d_tile_offsets);
+}

--- a/kernels/hybrid_binning/sort_and_rle.cu
+++ b/kernels/hybrid_binning/sort_and_rle.cu
@@ -9,26 +9,29 @@
 #include <device_launch_parameters.h>
 #include <cstdint>
 #include <cub/cub.cuh>
+#include <thrust/iterator/transform_iterator.h>
 
 // ---- 64-bit pair path: d_pairs = (tile_id << 32) | entity_id ----
 
-__global__ void extractKeysFromPairs64Kernel(
-    const unsigned long long* __restrict__ d_pairs,
-    unsigned int* __restrict__ d_keys,
-    unsigned int num_pairs)
-{
-    unsigned int i = blockIdx.x * blockDim.x + threadIdx.x;
-    if (i < num_pairs)
-        d_keys[i] = (unsigned int)(d_pairs[i] >> 32);
-}
+/** Functor: extracts tile_id (high 32 bits) from a 64-bit (tile_id, entity_id) pair.
+ *  Used with cub::TransformInputIterator to feed RLE without a separate extraction kernel. */
+struct ExtractTileId {
+    __host__ __device__ __forceinline__
+    unsigned int operator()(const unsigned long long& pair) const {
+        return static_cast<unsigned int>(pair >> 32);
+    }
+};
 
-/** Sort 64-bit pairs (tile_id in high 32 bits), run RLE on tile_id, build tile offsets. Entity index = low 32 bits, extracted in tiled raster. */
+using TileIdIterator = thrust::transform_iterator<ExtractTileId, const unsigned long long*, unsigned int>;
+
+/** Sort 64-bit pairs (tile_id in high 32 bits), run RLE on tile_id, build tile offsets.
+ *  Entity index = low 32 bits, extracted in tiled raster.
+ *  Uses TransformInputIterator to extract tile_id on-the-fly, avoiding a separate kernel + buffer. */
 extern "C" void sortPairs64AndBuildTileOffsets(
     unsigned long long* d_pairs_in,
     unsigned long long* d_pairs_out,
     unsigned int num_pairs,
     unsigned int total_tiles,
-    unsigned int* d_keys_extract,      /* temp: size num_pairs, holds tile_id per element for RLE input */
     unsigned int* d_tile_offsets,
     unsigned int* d_unique_out,
     unsigned int* d_counts_out,
@@ -57,14 +60,12 @@ extern "C" void sortPairs64AndBuildTileOffsets(
         0, 64,
         stream);
 
-    // 2) Extract tile_id (high 32 bits) for RLE
-    extractKeysFromPairs64Kernel<<<(num_pairs + 255) / 256, 256, 0, stream>>>(d_pairs_out, d_keys_extract, num_pairs);
-
-    // 3) Run-length encode on tile ids
+    // 2) Run-length encode: TransformInputIterator extracts tile_id (high 32 bits) lazily from sorted pairs
+    TileIdIterator tile_id_iter(d_pairs_out, ExtractTileId{});
     cub::DeviceRunLengthEncode::Encode(
         d_temp_storage_rle,
         temp_storage_bytes_rle,
-        d_keys_extract,
+        tile_id_iter,
         d_unique_out,
         d_counts_out,
         d_num_runs,
@@ -130,6 +131,18 @@ extern "C" void sortPairsAndBuildTileOffsets(
     // then call buildTileOffsetsFromRLE and launchScatterAndFillTileOffsets.
 }
 
+/** Query CUB for the temp storage bytes needed by RLE with TransformInputIterator on 64-bit pairs.
+ *  Callers use this during resource init instead of computing it directly (avoids exposing the iterator type). */
+extern "C" void getRleTempStorageBytesForPairs64(size_t* out_bytes, int maxPairs) {
+    *out_bytes = 0;
+    TileIdIterator dummy_iter(nullptr, ExtractTileId{});
+    cub::DeviceRunLengthEncode::Encode(
+        nullptr, *out_bytes,
+        dummy_iter,
+        (unsigned int*)nullptr, (unsigned int*)nullptr,
+        (unsigned int*)nullptr, maxPairs);
+}
+
 extern "C" void buildTileOffsetsFromRLE(
     const unsigned int* d_unique_out,
     const unsigned int* d_counts_out,
@@ -180,18 +193,18 @@ __global__ void scatterTileOffsetsKernel(
     }
 }
 
-// Kernel: fill gaps (tiles with no entities). Single-thread sequential pass so propagation is correct.
+// Kernel: fill gaps (tiles with no entities).
+// Must propagate BACKWARD so empty tiles get the offset of the NEXT occupied tile.
+// Forward propagation is wrong: it copies the START of the previous tile, stealing its entities.
 __global__ void fillTileOffsetsGapsKernel(
     unsigned int total_tiles,
     unsigned int* __restrict__ tileOffsets)
 {
     if (threadIdx.x != 0 || blockIdx.x != 0) return;
-    unsigned int last = 0u;
-    for (unsigned int t = 0; t < total_tiles; ++t) {
-        if (tileOffsets[t] != 0xFFFFFFFFu)
-            last = tileOffsets[t];
-        else
-            tileOffsets[t] = last;
+    // tileOffsets[total_tiles] = num_pairs (set by scatter kernel) acts as sentinel.
+    for (int t = (int)total_tiles - 1; t >= 0; --t) {
+        if (tileOffsets[t] == 0xFFFFFFFFu)
+            tileOffsets[t] = tileOffsets[t + 1];
     }
 }
 

--- a/kernels/hybrid_binning/sphere_pipeline_binning.cu
+++ b/kernels/hybrid_binning/sphere_pipeline_binning.cu
@@ -39,25 +39,6 @@ extern "C" void sortPairs64AndBuildTileOffsets(
     size_t temp_scan_bytes,
     cudaStream_t stream);
 extern "C" void getRleTempStorageBytesForPairs64(size_t* out_bytes, int maxPairs);
-extern "C" void buildTileOffsetsFromRLE(
-    const unsigned int* d_unique_out,
-    const unsigned int* d_counts_out,
-    unsigned int num_runs,
-    unsigned int num_pairs,
-    unsigned int total_tiles,
-    unsigned int* d_run_offsets,
-    unsigned int* d_tile_offsets,
-    void* d_temp_scan,
-    size_t temp_scan_bytes,
-    cudaStream_t stream);
-extern "C" void launchScatterAndFillTileOffsets(
-    const unsigned int* d_unique_out,
-    const unsigned int* d_run_offsets,
-    unsigned int num_runs,
-    unsigned int num_pairs,
-    unsigned int total_tiles,
-    unsigned int* d_tile_offsets,
-    cudaStream_t stream);
 extern "C" void launchSmallSphereRaster(
     const glm::vec4* d_spheres,
     const unsigned int* d_smallSphereIndices,
@@ -65,18 +46,25 @@ extern "C" void launchSmallSphereRaster(
     unsigned int* d_depthBuffer,
     cudaSurfaceObject_t outputImage,
     cudaStream_t stream);
-extern "C" void launchTiledSphereRasterBinning(
+extern "C" void launchExpandWorkGroups(
+    const unsigned int* d_unique_out,
+    const unsigned int* d_counts_out,
+    const unsigned int* d_run_offsets,
+    unsigned int numRuns,
+    unsigned int* d_wg_tileId,
+    unsigned int* d_wg_entityStart,
+    unsigned int* d_wg_entityCount,
+    unsigned int* d_wg_totalCount,
+    cudaStream_t stream);
+extern "C" void launchTiledSphereRasterWG(
     const glm::vec4* d_spheres,
-    const unsigned int* d_tile_offsets,
     const unsigned long long* d_tile_entity_pairs_sorted,
+    const unsigned int* d_wg_tileId,
+    const unsigned int* d_wg_entityStart,
+    const unsigned int* d_wg_entityCount,
+    unsigned int totalWorkGroups,
     unsigned int* d_depthBuffer,
     cudaSurfaceObject_t outputImage,
-    unsigned int tilesX,
-    unsigned int tilesY,
-    unsigned int* d_lightTileList,
-    unsigned int* d_heavyTileIndices,
-    unsigned int* d_heavyBatchStarts,
-    unsigned int* d_tileClassifyCounts,
     cudaStream_t stream);
 
 #define CUDA_CHECK(call) do { cudaError_t e = call; if (e != cudaSuccess) printf("CUDA error %d: %s\n", e, cudaGetErrorString(e)); } while(0)
@@ -123,7 +111,14 @@ void initSphereBinningResources(SphereBinningResources* r, int maxSpheres, int t
     if (r->temp_sort64_bytes > 0) CUDA_CHECK(cudaMalloc(&r->d_temp_sort64, r->temp_sort64_bytes));
     if (r->temp_rle_bytes > 0) CUDA_CHECK(cudaMalloc(&r->d_temp_rle, r->temp_rle_bytes));
     if (r->temp_scan_bytes > 0) CUDA_CHECK(cudaMalloc(&r->d_temp_scan, r->temp_scan_bytes));
-    CUDA_CHECK(cudaMalloc(&r->d_tileClassifyCounts, 2 * sizeof(unsigned int)));
+
+    // Work-group expansion buffers
+    r->maxWorkGroups = r->maxPairs / SHARED_BATCH_SIZE + totalTiles;
+    CUDA_CHECK(cudaMalloc(&r->d_wg_tileId, r->maxWorkGroups * sizeof(unsigned int)));
+    CUDA_CHECK(cudaMalloc(&r->d_wg_entityStart, r->maxWorkGroups * sizeof(unsigned int)));
+    CUDA_CHECK(cudaMalloc(&r->d_wg_entityCount, r->maxWorkGroups * sizeof(unsigned int)));
+    CUDA_CHECK(cudaMalloc(&r->d_wg_totalCount, sizeof(unsigned int)));
+    CUDA_CHECK(cudaHostAlloc(&r->h_wg_totalCount, sizeof(unsigned int), cudaHostAllocDefault));
 }
 
 void freeSphereBinningResources(SphereBinningResources* r) {
@@ -145,7 +140,11 @@ void freeSphereBinningResources(SphereBinningResources* r) {
     if (r->d_temp_sort64) cudaFree(r->d_temp_sort64);
     if (r->d_temp_rle) cudaFree(r->d_temp_rle);
     if (r->d_temp_scan) cudaFree(r->d_temp_scan);
-    cudaFree(r->d_tileClassifyCounts);
+    cudaFree(r->d_wg_tileId);
+    cudaFree(r->d_wg_entityStart);
+    cudaFree(r->d_wg_entityCount);
+    cudaFree(r->d_wg_totalCount);
+    cudaFreeHost(r->h_wg_totalCount);
 }
 
 void resetSphereBinningCounters(SphereBinningResources* r, cudaStream_t stream) {
@@ -196,29 +195,36 @@ void executeSpherePipelineBinning(
         cudaStreamSynchronize(stream);
         if (numRuns > numPairs) numRuns = numPairs;
 
-        buildTileOffsetsFromRLE(
-            r->d_unique_out, r->d_counts_out, numRuns, numPairs, r->totalTiles,
-            r->d_run_offsets, r->d_tile_offsets,
-            r->d_temp_scan, r->temp_scan_bytes, stream);
-        launchScatterAndFillTileOffsets(
-            r->d_unique_out, r->d_run_offsets, numRuns, numPairs, r->totalTiles,
-            r->d_tile_offsets, stream);
-    } else {
-        cudaMemsetAsync(r->d_tile_offsets, 0, (r->totalTiles + 1) * sizeof(unsigned int), stream);
+        // ExclusiveSum on counts -> run_offsets (start of each tile's entities in sorted array)
+        cub::DeviceScan::ExclusiveSum(
+            r->d_temp_scan, r->temp_scan_bytes,
+            r->d_counts_out, r->d_run_offsets,
+            numRuns, stream);
+
+        // Expand RLE runs into work-group dispatch list
+        cudaMemsetAsync(r->d_wg_totalCount, 0, sizeof(unsigned int), stream);
+        launchExpandWorkGroups(
+            r->d_unique_out, r->d_counts_out, r->d_run_offsets, numRuns,
+            r->d_wg_tileId, r->d_wg_entityStart, r->d_wg_entityCount,
+            r->d_wg_totalCount, stream);
+
+        // Read total work groups
+        cudaMemcpyAsync(r->h_wg_totalCount, r->d_wg_totalCount,
+            sizeof(unsigned int), cudaMemcpyDeviceToHost, stream);
+        cudaStreamSynchronize(stream);
+        unsigned int totalWorkGroups = *r->h_wg_totalCount;
+
+        // Launch tiled sphere raster
+        if (totalWorkGroups > 0) {
+            launchTiledSphereRasterWG(
+                d_spheres, r->d_tile_entity_pairs_sorted,
+                r->d_wg_tileId, r->d_wg_entityStart, r->d_wg_entityCount,
+                totalWorkGroups, d_depthBuffer, outputImage, stream);
+        }
     }
 
     if (smallCount > 0) {
         launchSmallSphereRaster(d_spheres, r->d_smallIndices, smallCount, d_depthBuffer, outputImage, stream);
-    }
-
-    // TODO: Re-enable when sort/RLE/tile-offset pipeline is uncommented above.
-    // Without valid tile offsets, this reads garbage memory and crashes CUDA.
-    if (numPairs > 0) {
-        launchTiledSphereRasterBinning(
-            d_spheres, r->d_tile_offsets, r->d_tile_entity_pairs_sorted,
-            d_depthBuffer, outputImage, r->tilesX, r->tilesY,
-            r->d_unique_out, r->d_counts_out, r->d_run_offsets,
-            r->d_tileClassifyCounts, stream);
     }
 }
 

--- a/kernels/hybrid_binning/sphere_pipeline_binning.cu
+++ b/kernels/hybrid_binning/sphere_pipeline_binning.cu
@@ -73,6 +73,10 @@ extern "C" void launchTiledSphereRasterBinning(
     cudaSurfaceObject_t outputImage,
     unsigned int tilesX,
     unsigned int tilesY,
+    unsigned int* d_lightTileList,
+    unsigned int* d_heavyTileIndices,
+    unsigned int* d_heavyBatchStarts,
+    unsigned int* d_tileClassifyCounts,
     cudaStream_t stream);
 
 #define CUDA_CHECK(call) do { cudaError_t e = call; if (e != cudaSuccess) printf("CUDA error %d: %s\n", e, cudaGetErrorString(e)); } while(0)
@@ -119,6 +123,7 @@ void initSphereBinningResources(SphereBinningResources* r, int maxSpheres, int t
     if (r->temp_sort64_bytes > 0) CUDA_CHECK(cudaMalloc(&r->d_temp_sort64, r->temp_sort64_bytes));
     if (r->temp_rle_bytes > 0) CUDA_CHECK(cudaMalloc(&r->d_temp_rle, r->temp_rle_bytes));
     if (r->temp_scan_bytes > 0) CUDA_CHECK(cudaMalloc(&r->d_temp_scan, r->temp_scan_bytes));
+    CUDA_CHECK(cudaMalloc(&r->d_tileClassifyCounts, 2 * sizeof(unsigned int)));
 }
 
 void freeSphereBinningResources(SphereBinningResources* r) {
@@ -140,6 +145,7 @@ void freeSphereBinningResources(SphereBinningResources* r) {
     if (r->d_temp_sort64) cudaFree(r->d_temp_sort64);
     if (r->d_temp_rle) cudaFree(r->d_temp_rle);
     if (r->d_temp_scan) cudaFree(r->d_temp_scan);
+    cudaFree(r->d_tileClassifyCounts);
 }
 
 void resetSphereBinningCounters(SphereBinningResources* r, cudaStream_t stream) {
@@ -210,7 +216,9 @@ void executeSpherePipelineBinning(
     if (numPairs > 0) {
         launchTiledSphereRasterBinning(
             d_spheres, r->d_tile_offsets, r->d_tile_entity_pairs_sorted,
-            d_depthBuffer, outputImage, r->tilesX, r->tilesY, stream);
+            d_depthBuffer, outputImage, r->tilesX, r->tilesY,
+            r->d_unique_out, r->d_counts_out, r->d_run_offsets,
+            r->d_tileClassifyCounts, stream);
     }
 }
 

--- a/kernels/hybrid_binning/sphere_pipeline_binning.cu
+++ b/kernels/hybrid_binning/sphere_pipeline_binning.cu
@@ -26,7 +26,6 @@ extern "C" void sortPairs64AndBuildTileOffsets(
     unsigned long long* d_pairs_out,
     unsigned int num_pairs,
     unsigned int total_tiles,
-    unsigned int* d_keys_extract,
     unsigned int* d_tile_offsets,
     unsigned int* d_unique_out,
     unsigned int* d_counts_out,
@@ -39,6 +38,7 @@ extern "C" void sortPairs64AndBuildTileOffsets(
     void* d_temp_scan,
     size_t temp_scan_bytes,
     cudaStream_t stream);
+extern "C" void getRleTempStorageBytesForPairs64(size_t* out_bytes, int maxPairs);
 extern "C" void buildTileOffsetsFromRLE(
     const unsigned int* d_unique_out,
     const unsigned int* d_counts_out,
@@ -85,19 +85,20 @@ void initSphereBinningResources(SphereBinningResources* r, int maxSpheres, int t
     r->totalTiles = totalTiles;
     int avgPerTile = (avgEntitiesPerTile > 0) ? avgEntitiesPerTile : AVG_ENTITIES_PER_TILE;
     r->maxPairs = avgPerTile * totalTiles;
+    printf("Initializing SphereBinningResources with maxSpheres=%d, tilesX=%d, tilesY=%d, totalTiles=%d, avgEntitiesPerTile=%d, avgPerTile=%d, maxPairs=%d\n",
+        maxSpheres, tilesX, tilesY, totalTiles, avgEntitiesPerTile, avgPerTile, r->maxPairs);
     if (r->maxPairs < totalTiles * 4) r->maxPairs = totalTiles * 4;
 
     CUDA_CHECK(cudaMalloc(&r->d_smallIndices, maxSpheres * sizeof(unsigned int)));
     CUDA_CHECK(cudaMalloc(&r->d_smallCount, sizeof(unsigned int)));
     CUDA_CHECK(cudaMalloc(&r->d_frustumPassedCount, sizeof(unsigned int)));
+    CUDA_CHECK(cudaMalloc(&r->d_pairCount, sizeof(unsigned int)));
     CUDA_CHECK(cudaHostAlloc(&r->h_smallCount, sizeof(unsigned int), cudaHostAllocDefault));
     CUDA_CHECK(cudaHostAlloc(&r->h_pairCount, sizeof(unsigned int), cudaHostAllocDefault));
     CUDA_CHECK(cudaHostAlloc(&r->h_frustumPassedCount, sizeof(unsigned int), cudaHostAllocDefault));
 
-    CUDA_CHECK(cudaMalloc(&r->d_pairCount, sizeof(unsigned int)));
     CUDA_CHECK(cudaMalloc(&r->d_tile_entity_pairs, r->maxPairs * sizeof(unsigned long long)));
     CUDA_CHECK(cudaMalloc(&r->d_tile_entity_pairs_sorted, r->maxPairs * sizeof(unsigned long long)));
-    CUDA_CHECK(cudaMalloc(&r->d_keys_extract, r->maxPairs * sizeof(unsigned int)));
     CUDA_CHECK(cudaMalloc(&r->d_tile_offsets, (totalTiles + 1) * sizeof(unsigned int)));
     CUDA_CHECK(cudaMalloc(&r->d_unique_out, r->maxPairs * sizeof(unsigned int)));
     CUDA_CHECK(cudaMalloc(&r->d_counts_out, r->maxPairs * sizeof(unsigned int)));
@@ -112,9 +113,7 @@ void initSphereBinningResources(SphereBinningResources* r, int maxSpheres, int t
     r->d_temp_scan = nullptr;
     r->temp_rle_bytes = 0;
     r->temp_scan_bytes = 0;
-    cub::DeviceRunLengthEncode::Encode(nullptr, r->temp_rle_bytes,
-        (unsigned int*)nullptr, (unsigned int*)nullptr, (unsigned int*)nullptr,
-        (unsigned int*)nullptr, (int)r->maxPairs);
+    getRleTempStorageBytesForPairs64(&r->temp_rle_bytes, (int)r->maxPairs);
     cub::DeviceScan::ExclusiveSum(nullptr, r->temp_scan_bytes,
         (unsigned int*)nullptr, (unsigned int*)nullptr, (int)r->maxPairs);
     if (r->temp_sort64_bytes > 0) CUDA_CHECK(cudaMalloc(&r->d_temp_sort64, r->temp_sort64_bytes));
@@ -133,7 +132,6 @@ void freeSphereBinningResources(SphereBinningResources* r) {
     cudaFree(r->d_pairCount);
     cudaFree(r->d_tile_entity_pairs);
     cudaFree(r->d_tile_entity_pairs_sorted);
-    cudaFree(r->d_keys_extract);
     cudaFree(r->d_tile_offsets);
     cudaFree(r->d_unique_out);
     cudaFree(r->d_counts_out);
@@ -159,6 +157,7 @@ void executeSpherePipelineBinning(
     cudaStream_t stream)
 {
     if (sphereCount == 0) return;
+    
 
     launchSphereFrustumBBoxClassify(
         d_spheres, r->d_smallIndices, r->d_smallCount,
@@ -168,20 +167,20 @@ void executeSpherePipelineBinning(
     cudaMemcpyAsync(r->h_smallCount, r->d_smallCount, sizeof(unsigned int), cudaMemcpyDeviceToHost, stream);
     cudaMemcpyAsync(r->h_pairCount, r->d_pairCount, sizeof(unsigned int), cudaMemcpyDeviceToHost, stream);
     cudaMemcpyAsync(r->h_frustumPassedCount, r->d_frustumPassedCount, sizeof(unsigned int), cudaMemcpyDeviceToHost, stream);
-    cudaStreamSynchronize(stream);
+    // cudaStreamSynchronize(stream);
 
     unsigned int smallCount = *r->h_smallCount;
     unsigned int numPairs = *r->h_pairCount;
 
     if (numPairs > 0) {
         
-        cudaStreamSynchronize(stream);
+        // cudaStreamSynchronize(stream);
         if (numPairs > (unsigned int)r->maxPairs) numPairs = r->maxPairs;
 
         sortPairs64AndBuildTileOffsets(
             r->d_tile_entity_pairs, r->d_tile_entity_pairs_sorted,
             numPairs, r->totalTiles,
-            r->d_keys_extract, r->d_tile_offsets,
+            r->d_tile_offsets,
             r->d_unique_out, r->d_counts_out, r->d_run_offsets, r->d_num_runs,
             r->d_temp_sort64, r->temp_sort64_bytes,
             r->d_temp_rle, r->temp_rle_bytes,
@@ -206,6 +205,8 @@ void executeSpherePipelineBinning(
         launchSmallSphereRaster(d_spheres, r->d_smallIndices, smallCount, d_depthBuffer, outputImage, stream);
     }
 
+    // TODO: Re-enable when sort/RLE/tile-offset pipeline is uncommented above.
+    // Without valid tile offsets, this reads garbage memory and crashes CUDA.
     if (numPairs > 0) {
         launchTiledSphereRasterBinning(
             d_spheres, r->d_tile_offsets, r->d_tile_entity_pairs_sorted,

--- a/kernels/hybrid_binning/sphere_pipeline_binning.cu
+++ b/kernels/hybrid_binning/sphere_pipeline_binning.cu
@@ -1,0 +1,239 @@
+/**
+ * @file sphere_pipeline_binning.cu
+ * @brief Sphere pipeline: Classify -> Generate pairs -> Sort -> RLE -> tileOffsets -> Small/Tiled raster.
+ */
+
+#include <cuda_runtime.h>
+#include <cstdio>
+#include <cub/cub.cuh>
+#include "sphere_pipeline_binning.cuh"
+#include "hybrid_binning_types.h"
+
+extern "C" void uploadHybridConstants(const HybridConstants& constants, cudaStream_t stream);
+extern "C" void launchSphereFrustumBBoxClassify(
+    const glm::vec4* d_spheres,
+    unsigned int* d_smallSphereIndices,
+    unsigned int* d_smallSphereCount,
+    SphereBillboard* d_largeBillboards,
+    unsigned int* d_largeSphereCount,
+    unsigned int* d_frustumPassedCount,
+    int sphereCount,
+    cudaStream_t stream);
+extern "C" void launchGenerateSpherePairs(
+    const SphereBillboard* d_billboards,
+    unsigned int billboardCount,
+    unsigned int* d_keys,
+    unsigned int* d_values,
+    unsigned int* d_pairCount,
+    cudaStream_t stream);
+extern "C" void sortPairsAndBuildTileOffsets(
+    unsigned int* d_keys_in,
+    unsigned int* d_values_in,
+    unsigned int* d_keys_out,
+    unsigned int* d_values_out,
+    unsigned int num_pairs,
+    unsigned int total_tiles,
+    unsigned int* d_tile_offsets,
+    unsigned int* d_unique_out,
+    unsigned int* d_counts_out,
+    unsigned int* d_run_offsets,
+    unsigned int* d_num_runs,
+    void* d_temp_sort,
+    size_t temp_sort_bytes_sort,
+    void* d_temp_rle,
+    size_t temp_rle_bytes,
+    void* d_temp_scan,
+    size_t temp_scan_bytes,
+    cudaStream_t stream);
+extern "C" void buildTileOffsetsFromRLE(
+    const unsigned int* d_unique_out,
+    const unsigned int* d_counts_out,
+    unsigned int num_runs,
+    unsigned int num_pairs,
+    unsigned int total_tiles,
+    unsigned int* d_run_offsets,
+    unsigned int* d_tile_offsets,
+    void* d_temp_scan,
+    size_t temp_scan_bytes,
+    cudaStream_t stream);
+extern "C" void launchScatterAndFillTileOffsets(
+    const unsigned int* d_unique_out,
+    const unsigned int* d_run_offsets,
+    unsigned int num_runs,
+    unsigned int num_pairs,
+    unsigned int total_tiles,
+    unsigned int* d_tile_offsets,
+    cudaStream_t stream);
+extern "C" void launchSmallSphereRaster(
+    const glm::vec4* d_spheres,
+    const unsigned int* d_smallSphereIndices,
+    unsigned int smallSphereCount,
+    unsigned int* d_depthBuffer,
+    cudaSurfaceObject_t outputImage,
+    cudaStream_t stream);
+extern "C" void launchTiledSphereRasterBinning(
+    const glm::vec4* d_spheres,
+    const unsigned int* d_tile_offsets,
+    const unsigned int* d_sorted_entity_indices,
+    unsigned int* d_depthBuffer,
+    cudaSurfaceObject_t outputImage,
+    unsigned int tilesX,
+    unsigned int tilesY,
+    cudaStream_t stream);
+
+#define CUDA_CHECK(call) do { cudaError_t e = call; if (e != cudaSuccess) printf("CUDA error %d: %s\n", e, cudaGetErrorString(e)); } while(0)
+
+void initSphereBinningResources(SphereBinningResources* r, int maxSpheres, int tilesX, int tilesY, int totalTiles) {
+    cudaGetLastError();
+    r->maxSpheres = maxSpheres;
+    r->tilesX = tilesX;
+    r->tilesY = tilesY;
+    r->totalTiles = totalTiles;
+    r->maxPairs = maxSpheres * 64;
+    if (r->maxPairs < totalTiles * 4) r->maxPairs = totalTiles * 4;
+
+    CUDA_CHECK(cudaMalloc(&r->d_smallIndices, maxSpheres * sizeof(unsigned int)));
+    CUDA_CHECK(cudaMalloc(&r->d_smallCount, sizeof(unsigned int)));
+    CUDA_CHECK(cudaMalloc(&r->d_largeCount, sizeof(unsigned int)));
+    CUDA_CHECK(cudaMalloc(&r->d_largeBillboards, maxSpheres * sizeof(SphereBillboard)));
+    CUDA_CHECK(cudaMalloc(&r->d_frustumPassedCount, sizeof(unsigned int)));
+    CUDA_CHECK(cudaHostAlloc(&r->h_smallCount, sizeof(unsigned int), cudaHostAllocDefault));
+    CUDA_CHECK(cudaHostAlloc(&r->h_largeCount, sizeof(unsigned int), cudaHostAllocDefault));
+    CUDA_CHECK(cudaHostAlloc(&r->h_frustumPassedCount, sizeof(unsigned int), cudaHostAllocDefault));
+
+    CUDA_CHECK(cudaMalloc(&r->d_pairCount, sizeof(unsigned int)));
+    CUDA_CHECK(cudaMalloc(&r->d_keys_in, r->maxPairs * sizeof(unsigned int)));
+    CUDA_CHECK(cudaMalloc(&r->d_values_in, r->maxPairs * sizeof(unsigned int)));
+    CUDA_CHECK(cudaMalloc(&r->d_keys_out, r->maxPairs * sizeof(unsigned int)));
+    CUDA_CHECK(cudaMalloc(&r->d_values_out, r->maxPairs * sizeof(unsigned int)));
+    CUDA_CHECK(cudaMalloc(&r->d_tile_offsets, (totalTiles + 1) * sizeof(unsigned int)));
+    CUDA_CHECK(cudaMalloc(&r->d_unique_out, r->maxPairs * sizeof(unsigned int)));
+    CUDA_CHECK(cudaMalloc(&r->d_counts_out, r->maxPairs * sizeof(unsigned int)));
+    CUDA_CHECK(cudaMalloc(&r->d_run_offsets, r->maxPairs * sizeof(unsigned int)));
+    CUDA_CHECK(cudaMalloc(&r->d_num_runs, sizeof(unsigned int)));
+
+    r->d_temp_sort = nullptr;
+    r->d_temp_rle = nullptr;
+    r->d_temp_scan = nullptr;
+    r->temp_sort_bytes = 0;
+    r->temp_rle_bytes = 0;
+    r->temp_scan_bytes = 0;
+    sortPairsAndBuildTileOffsets(
+        r->d_keys_in, r->d_values_in, r->d_keys_out, r->d_values_out,
+        1, totalTiles, r->d_tile_offsets, r->d_unique_out, r->d_counts_out,
+        r->d_run_offsets, r->d_num_runs,
+        nullptr, r->temp_sort_bytes, nullptr, r->temp_rle_bytes,
+        nullptr, r->temp_scan_bytes, nullptr);
+    r->d_temp_rle = nullptr;
+    r->d_temp_scan = nullptr;
+    size_t scan_bytes = 0;
+    cub::DeviceScan::ExclusiveSum(nullptr, scan_bytes, (unsigned int*)nullptr, (unsigned int*)nullptr, (int)r->maxPairs);
+    if (scan_bytes > r->temp_scan_bytes) r->temp_scan_bytes = scan_bytes;
+    if (r->temp_sort_bytes > 0) CUDA_CHECK(cudaMalloc(&r->d_temp_sort, r->temp_sort_bytes));
+    if (r->temp_rle_bytes > 0) CUDA_CHECK(cudaMalloc(&r->d_temp_rle, r->temp_rle_bytes));
+    if (r->temp_scan_bytes > 0) CUDA_CHECK(cudaMalloc(&r->d_temp_scan, r->temp_scan_bytes));
+}
+
+void freeSphereBinningResources(SphereBinningResources* r) {
+    if (!r) return;
+    cudaFree(r->d_smallIndices);
+    cudaFree(r->d_smallCount);
+    cudaFree(r->d_largeCount);
+    cudaFree(r->d_largeBillboards);
+    cudaFree(r->d_frustumPassedCount);
+    cudaFreeHost(r->h_smallCount);
+    cudaFreeHost(r->h_largeCount);
+    cudaFreeHost(r->h_frustumPassedCount);
+    cudaFree(r->d_pairCount);
+    cudaFree(r->d_keys_in);
+    cudaFree(r->d_values_in);
+    cudaFree(r->d_keys_out);
+    cudaFree(r->d_values_out);
+    cudaFree(r->d_tile_offsets);
+    cudaFree(r->d_unique_out);
+    cudaFree(r->d_counts_out);
+    cudaFree(r->d_run_offsets);
+    cudaFree(r->d_num_runs);
+    if (r->d_temp_sort) cudaFree(r->d_temp_sort);
+    if (r->d_temp_rle) cudaFree(r->d_temp_rle);
+    if (r->d_temp_scan) cudaFree(r->d_temp_scan);
+}
+
+void resetSphereBinningCounters(SphereBinningResources* r, cudaStream_t stream) {
+    cudaMemsetAsync(r->d_smallCount, 0, sizeof(unsigned int), stream);
+    cudaMemsetAsync(r->d_largeCount, 0, sizeof(unsigned int), stream);
+    cudaMemsetAsync(r->d_frustumPassedCount, 0, sizeof(unsigned int), stream);
+}
+
+void executeSpherePipelineBinning(
+    const glm::vec4* d_spheres,
+    int sphereCount,
+    unsigned int* d_depthBuffer,
+    cudaSurfaceObject_t outputImage,
+    SphereBinningResources* r,
+    cudaStream_t stream)
+{
+    if (sphereCount == 0) return;
+
+    launchSphereFrustumBBoxClassify(
+        d_spheres, r->d_smallIndices, r->d_smallCount,
+        r->d_largeBillboards, r->d_largeCount, r->d_frustumPassedCount,
+        sphereCount, stream);
+
+    cudaMemcpyAsync(r->h_smallCount, r->d_smallCount, sizeof(unsigned int), cudaMemcpyDeviceToHost, stream);
+    cudaMemcpyAsync(r->h_largeCount, r->d_largeCount, sizeof(unsigned int), cudaMemcpyDeviceToHost, stream);
+    cudaMemcpyAsync(r->h_frustumPassedCount, r->d_frustumPassedCount, sizeof(unsigned int), cudaMemcpyDeviceToHost, stream);
+    cudaStreamSynchronize(stream);
+
+    unsigned int smallCount = *r->h_smallCount;
+    unsigned int largeCount = *r->h_largeCount;
+
+    if (largeCount > 0) {
+        launchGenerateSpherePairs(
+            r->d_largeBillboards, largeCount,
+            r->d_keys_in, r->d_values_in, r->d_pairCount, stream);
+        unsigned int numPairs;
+        cudaMemcpyAsync(&numPairs, r->d_pairCount, sizeof(unsigned int), cudaMemcpyDeviceToHost, stream);
+        cudaStreamSynchronize(stream);
+        if (numPairs > (unsigned int)r->maxPairs) numPairs = r->maxPairs;
+
+        sortPairsAndBuildTileOffsets(
+            r->d_keys_in, r->d_values_in, r->d_keys_out, r->d_values_out,
+            numPairs, r->totalTiles, r->d_tile_offsets,
+            r->d_unique_out, r->d_counts_out, r->d_run_offsets, r->d_num_runs,
+            r->d_temp_sort, r->temp_sort_bytes,
+            r->d_temp_rle, r->temp_rle_bytes,
+            r->d_temp_scan, r->temp_scan_bytes, stream);
+        unsigned int numRuns;
+        cudaMemcpyAsync(&numRuns, r->d_num_runs, sizeof(unsigned int), cudaMemcpyDeviceToHost, stream);
+        cudaStreamSynchronize(stream);
+
+        buildTileOffsetsFromRLE(
+            r->d_unique_out, r->d_counts_out, numRuns, numPairs, r->totalTiles,
+            r->d_run_offsets, r->d_tile_offsets,
+            r->d_temp_scan, r->temp_scan_bytes, stream);
+        launchScatterAndFillTileOffsets(
+            r->d_unique_out, r->d_run_offsets, numRuns, numPairs, r->totalTiles,
+            r->d_tile_offsets, stream);
+    } else {
+        cudaMemsetAsync(r->d_tile_offsets, 0, (r->totalTiles + 1) * sizeof(unsigned int), stream);
+    }
+
+    if (smallCount > 0) {
+        launchSmallSphereRaster(d_spheres, r->d_smallIndices, smallCount, d_depthBuffer, outputImage, stream);
+    }
+
+    if (largeCount > 0) {
+        launchTiledSphereRasterBinning(
+            d_spheres, r->d_tile_offsets, r->d_values_out,
+            d_depthBuffer, outputImage, r->tilesX, r->tilesY, stream);
+    }
+}
+
+void getSphereBinningStats(SphereBinningResources* r,
+    unsigned int* outFrustumPassed, unsigned int* outSmallCount, unsigned int* outLargeCount)
+{
+    if (outFrustumPassed) *outFrustumPassed = *r->h_frustumPassedCount;
+    if (outSmallCount) *outSmallCount = *r->h_smallCount;
+    if (outLargeCount) *outLargeCount = *r->h_largeCount;
+}

--- a/kernels/hybrid_binning/sphere_pipeline_binning.cu
+++ b/kernels/hybrid_binning/sphere_pipeline_binning.cu
@@ -5,6 +5,7 @@
 
 #include <cuda_runtime.h>
 #include <cstdio>
+#include <cstdint>
 #include <cub/cub.cuh>
 #include "sphere_pipeline_binning.cuh"
 #include "hybrid_binning_types.h"
@@ -14,32 +15,25 @@ extern "C" void launchSphereFrustumBBoxClassify(
     const glm::vec4* d_spheres,
     unsigned int* d_smallSphereIndices,
     unsigned int* d_smallSphereCount,
-    SphereBillboard* d_largeBillboards,
-    unsigned int* d_largeSphereCount,
+    unsigned long long* d_tile_entity_pairs,
+    unsigned int* d_pair_count,
     unsigned int* d_frustumPassedCount,
     int sphereCount,
+    int maxPairs,
     cudaStream_t stream);
-extern "C" void launchGenerateSpherePairs(
-    const SphereBillboard* d_billboards,
-    unsigned int billboardCount,
-    unsigned int* d_keys,
-    unsigned int* d_values,
-    unsigned int* d_pairCount,
-    cudaStream_t stream);
-extern "C" void sortPairsAndBuildTileOffsets(
-    unsigned int* d_keys_in,
-    unsigned int* d_values_in,
-    unsigned int* d_keys_out,
-    unsigned int* d_values_out,
+extern "C" void sortPairs64AndBuildTileOffsets(
+    unsigned long long* d_pairs_in,
+    unsigned long long* d_pairs_out,
     unsigned int num_pairs,
     unsigned int total_tiles,
+    unsigned int* d_keys_extract,
     unsigned int* d_tile_offsets,
     unsigned int* d_unique_out,
     unsigned int* d_counts_out,
     unsigned int* d_run_offsets,
     unsigned int* d_num_runs,
-    void* d_temp_sort,
-    size_t temp_sort_bytes_sort,
+    void* d_temp_sort64,
+    size_t temp_sort64_bytes,
     void* d_temp_rle,
     size_t temp_rle_bytes,
     void* d_temp_scan,
@@ -74,7 +68,7 @@ extern "C" void launchSmallSphereRaster(
 extern "C" void launchTiledSphereRasterBinning(
     const glm::vec4* d_spheres,
     const unsigned int* d_tile_offsets,
-    const unsigned int* d_sorted_entity_indices,
+    const unsigned long long* d_tile_entity_pairs_sorted,
     unsigned int* d_depthBuffer,
     cudaSurfaceObject_t outputImage,
     unsigned int tilesX,
@@ -83,53 +77,47 @@ extern "C" void launchTiledSphereRasterBinning(
 
 #define CUDA_CHECK(call) do { cudaError_t e = call; if (e != cudaSuccess) printf("CUDA error %d: %s\n", e, cudaGetErrorString(e)); } while(0)
 
-void initSphereBinningResources(SphereBinningResources* r, int maxSpheres, int tilesX, int tilesY, int totalTiles) {
+void initSphereBinningResources(SphereBinningResources* r, int maxSpheres, int tilesX, int tilesY, int totalTiles, int avgEntitiesPerTile) {
     cudaGetLastError();
     r->maxSpheres = maxSpheres;
     r->tilesX = tilesX;
     r->tilesY = tilesY;
     r->totalTiles = totalTiles;
-    r->maxPairs = maxSpheres * 64;
+    int avgPerTile = (avgEntitiesPerTile > 0) ? avgEntitiesPerTile : AVG_ENTITIES_PER_TILE;
+    r->maxPairs = avgPerTile * totalTiles;
     if (r->maxPairs < totalTiles * 4) r->maxPairs = totalTiles * 4;
 
     CUDA_CHECK(cudaMalloc(&r->d_smallIndices, maxSpheres * sizeof(unsigned int)));
     CUDA_CHECK(cudaMalloc(&r->d_smallCount, sizeof(unsigned int)));
-    CUDA_CHECK(cudaMalloc(&r->d_largeCount, sizeof(unsigned int)));
-    CUDA_CHECK(cudaMalloc(&r->d_largeBillboards, maxSpheres * sizeof(SphereBillboard)));
     CUDA_CHECK(cudaMalloc(&r->d_frustumPassedCount, sizeof(unsigned int)));
     CUDA_CHECK(cudaHostAlloc(&r->h_smallCount, sizeof(unsigned int), cudaHostAllocDefault));
-    CUDA_CHECK(cudaHostAlloc(&r->h_largeCount, sizeof(unsigned int), cudaHostAllocDefault));
+    CUDA_CHECK(cudaHostAlloc(&r->h_pairCount, sizeof(unsigned int), cudaHostAllocDefault));
     CUDA_CHECK(cudaHostAlloc(&r->h_frustumPassedCount, sizeof(unsigned int), cudaHostAllocDefault));
 
     CUDA_CHECK(cudaMalloc(&r->d_pairCount, sizeof(unsigned int)));
-    CUDA_CHECK(cudaMalloc(&r->d_keys_in, r->maxPairs * sizeof(unsigned int)));
-    CUDA_CHECK(cudaMalloc(&r->d_values_in, r->maxPairs * sizeof(unsigned int)));
-    CUDA_CHECK(cudaMalloc(&r->d_keys_out, r->maxPairs * sizeof(unsigned int)));
-    CUDA_CHECK(cudaMalloc(&r->d_values_out, r->maxPairs * sizeof(unsigned int)));
+    CUDA_CHECK(cudaMalloc(&r->d_tile_entity_pairs, r->maxPairs * sizeof(unsigned long long)));
+    CUDA_CHECK(cudaMalloc(&r->d_tile_entity_pairs_sorted, r->maxPairs * sizeof(unsigned long long)));
+    CUDA_CHECK(cudaMalloc(&r->d_keys_extract, r->maxPairs * sizeof(unsigned int)));
     CUDA_CHECK(cudaMalloc(&r->d_tile_offsets, (totalTiles + 1) * sizeof(unsigned int)));
     CUDA_CHECK(cudaMalloc(&r->d_unique_out, r->maxPairs * sizeof(unsigned int)));
     CUDA_CHECK(cudaMalloc(&r->d_counts_out, r->maxPairs * sizeof(unsigned int)));
     CUDA_CHECK(cudaMalloc(&r->d_run_offsets, r->maxPairs * sizeof(unsigned int)));
     CUDA_CHECK(cudaMalloc(&r->d_num_runs, sizeof(unsigned int)));
 
-    r->d_temp_sort = nullptr;
+    r->d_temp_sort64 = nullptr;
+    r->temp_sort64_bytes = 0;
+    cub::DeviceRadixSort::SortKeys(nullptr, r->temp_sort64_bytes,
+        (unsigned long long*)nullptr, (unsigned long long*)nullptr, (int)r->maxPairs, 0, 64);
     r->d_temp_rle = nullptr;
     r->d_temp_scan = nullptr;
-    r->temp_sort_bytes = 0;
     r->temp_rle_bytes = 0;
     r->temp_scan_bytes = 0;
-    sortPairsAndBuildTileOffsets(
-        r->d_keys_in, r->d_values_in, r->d_keys_out, r->d_values_out,
-        1, totalTiles, r->d_tile_offsets, r->d_unique_out, r->d_counts_out,
-        r->d_run_offsets, r->d_num_runs,
-        nullptr, r->temp_sort_bytes, nullptr, r->temp_rle_bytes,
-        nullptr, r->temp_scan_bytes, nullptr);
-    r->d_temp_rle = nullptr;
-    r->d_temp_scan = nullptr;
-    size_t scan_bytes = 0;
-    cub::DeviceScan::ExclusiveSum(nullptr, scan_bytes, (unsigned int*)nullptr, (unsigned int*)nullptr, (int)r->maxPairs);
-    if (scan_bytes > r->temp_scan_bytes) r->temp_scan_bytes = scan_bytes;
-    if (r->temp_sort_bytes > 0) CUDA_CHECK(cudaMalloc(&r->d_temp_sort, r->temp_sort_bytes));
+    cub::DeviceRunLengthEncode::Encode(nullptr, r->temp_rle_bytes,
+        (unsigned int*)nullptr, (unsigned int*)nullptr, (unsigned int*)nullptr,
+        (unsigned int*)nullptr, (int)r->maxPairs);
+    cub::DeviceScan::ExclusiveSum(nullptr, r->temp_scan_bytes,
+        (unsigned int*)nullptr, (unsigned int*)nullptr, (int)r->maxPairs);
+    if (r->temp_sort64_bytes > 0) CUDA_CHECK(cudaMalloc(&r->d_temp_sort64, r->temp_sort64_bytes));
     if (r->temp_rle_bytes > 0) CUDA_CHECK(cudaMalloc(&r->d_temp_rle, r->temp_rle_bytes));
     if (r->temp_scan_bytes > 0) CUDA_CHECK(cudaMalloc(&r->d_temp_scan, r->temp_scan_bytes));
 }
@@ -138,31 +126,28 @@ void freeSphereBinningResources(SphereBinningResources* r) {
     if (!r) return;
     cudaFree(r->d_smallIndices);
     cudaFree(r->d_smallCount);
-    cudaFree(r->d_largeCount);
-    cudaFree(r->d_largeBillboards);
     cudaFree(r->d_frustumPassedCount);
     cudaFreeHost(r->h_smallCount);
-    cudaFreeHost(r->h_largeCount);
+    cudaFreeHost(r->h_pairCount);
     cudaFreeHost(r->h_frustumPassedCount);
     cudaFree(r->d_pairCount);
-    cudaFree(r->d_keys_in);
-    cudaFree(r->d_values_in);
-    cudaFree(r->d_keys_out);
-    cudaFree(r->d_values_out);
+    cudaFree(r->d_tile_entity_pairs);
+    cudaFree(r->d_tile_entity_pairs_sorted);
+    cudaFree(r->d_keys_extract);
     cudaFree(r->d_tile_offsets);
     cudaFree(r->d_unique_out);
     cudaFree(r->d_counts_out);
     cudaFree(r->d_run_offsets);
     cudaFree(r->d_num_runs);
-    if (r->d_temp_sort) cudaFree(r->d_temp_sort);
+    if (r->d_temp_sort64) cudaFree(r->d_temp_sort64);
     if (r->d_temp_rle) cudaFree(r->d_temp_rle);
     if (r->d_temp_scan) cudaFree(r->d_temp_scan);
 }
 
 void resetSphereBinningCounters(SphereBinningResources* r, cudaStream_t stream) {
     cudaMemsetAsync(r->d_smallCount, 0, sizeof(unsigned int), stream);
-    cudaMemsetAsync(r->d_largeCount, 0, sizeof(unsigned int), stream);
     cudaMemsetAsync(r->d_frustumPassedCount, 0, sizeof(unsigned int), stream);
+    cudaMemsetAsync(r->d_pairCount, 0, sizeof(unsigned int), stream);
 }
 
 void executeSpherePipelineBinning(
@@ -177,36 +162,34 @@ void executeSpherePipelineBinning(
 
     launchSphereFrustumBBoxClassify(
         d_spheres, r->d_smallIndices, r->d_smallCount,
-        r->d_largeBillboards, r->d_largeCount, r->d_frustumPassedCount,
-        sphereCount, stream);
+        r->d_tile_entity_pairs, r->d_pairCount, r->d_frustumPassedCount,
+        sphereCount, r->maxPairs, stream);
 
     cudaMemcpyAsync(r->h_smallCount, r->d_smallCount, sizeof(unsigned int), cudaMemcpyDeviceToHost, stream);
-    cudaMemcpyAsync(r->h_largeCount, r->d_largeCount, sizeof(unsigned int), cudaMemcpyDeviceToHost, stream);
+    cudaMemcpyAsync(r->h_pairCount, r->d_pairCount, sizeof(unsigned int), cudaMemcpyDeviceToHost, stream);
     cudaMemcpyAsync(r->h_frustumPassedCount, r->d_frustumPassedCount, sizeof(unsigned int), cudaMemcpyDeviceToHost, stream);
     cudaStreamSynchronize(stream);
 
     unsigned int smallCount = *r->h_smallCount;
-    unsigned int largeCount = *r->h_largeCount;
+    unsigned int numPairs = *r->h_pairCount;
 
-    if (largeCount > 0) {
-        launchGenerateSpherePairs(
-            r->d_largeBillboards, largeCount,
-            r->d_keys_in, r->d_values_in, r->d_pairCount, stream);
-        unsigned int numPairs;
-        cudaMemcpyAsync(&numPairs, r->d_pairCount, sizeof(unsigned int), cudaMemcpyDeviceToHost, stream);
+    if (numPairs > 0) {
+        
         cudaStreamSynchronize(stream);
         if (numPairs > (unsigned int)r->maxPairs) numPairs = r->maxPairs;
 
-        sortPairsAndBuildTileOffsets(
-            r->d_keys_in, r->d_values_in, r->d_keys_out, r->d_values_out,
-            numPairs, r->totalTiles, r->d_tile_offsets,
+        sortPairs64AndBuildTileOffsets(
+            r->d_tile_entity_pairs, r->d_tile_entity_pairs_sorted,
+            numPairs, r->totalTiles,
+            r->d_keys_extract, r->d_tile_offsets,
             r->d_unique_out, r->d_counts_out, r->d_run_offsets, r->d_num_runs,
-            r->d_temp_sort, r->temp_sort_bytes,
+            r->d_temp_sort64, r->temp_sort64_bytes,
             r->d_temp_rle, r->temp_rle_bytes,
             r->d_temp_scan, r->temp_scan_bytes, stream);
         unsigned int numRuns;
         cudaMemcpyAsync(&numRuns, r->d_num_runs, sizeof(unsigned int), cudaMemcpyDeviceToHost, stream);
         cudaStreamSynchronize(stream);
+        if (numRuns > numPairs) numRuns = numPairs;
 
         buildTileOffsetsFromRLE(
             r->d_unique_out, r->d_counts_out, numRuns, numPairs, r->totalTiles,
@@ -223,9 +206,9 @@ void executeSpherePipelineBinning(
         launchSmallSphereRaster(d_spheres, r->d_smallIndices, smallCount, d_depthBuffer, outputImage, stream);
     }
 
-    if (largeCount > 0) {
+    if (numPairs > 0) {
         launchTiledSphereRasterBinning(
-            d_spheres, r->d_tile_offsets, r->d_values_out,
+            d_spheres, r->d_tile_offsets, r->d_tile_entity_pairs_sorted,
             d_depthBuffer, outputImage, r->tilesX, r->tilesY, stream);
     }
 }
@@ -235,5 +218,5 @@ void getSphereBinningStats(SphereBinningResources* r,
 {
     if (outFrustumPassed) *outFrustumPassed = *r->h_frustumPassedCount;
     if (outSmallCount) *outSmallCount = *r->h_smallCount;
-    if (outLargeCount) *outLargeCount = *r->h_largeCount;
+    if (outLargeCount) *outLargeCount = *r->h_pairCount;
 }

--- a/kernels/hybrid_binning/sphere_pipeline_binning.cuh
+++ b/kernels/hybrid_binning/sphere_pipeline_binning.cuh
@@ -12,24 +12,24 @@
 struct SphereBinningResources {
     unsigned int* d_smallIndices;
     unsigned int* d_smallCount;
-    unsigned int* d_largeCount;
-    SphereBillboard* d_largeBillboards;
     unsigned int* d_frustumPassedCount;
     unsigned int* h_smallCount;
-    unsigned int* h_largeCount;
+    unsigned int* h_pairCount;
     unsigned int* h_frustumPassedCount;
+    /** 64-bit buffer: (tile_id << 32) | entity_id, written by classifier with atomics */
+    unsigned long long* d_tile_entity_pairs;
+    /** Sorted 64-bit pairs (output of radix sort) */
+    unsigned long long* d_tile_entity_pairs_sorted;
     unsigned int* d_pairCount;
-    unsigned int* d_keys_in;
-    unsigned int* d_values_in;
-    unsigned int* d_keys_out;
-    unsigned int* d_values_out;
+    /** Temp: tile_id per element for RLE input (extracted from 64-bit pairs) */
+    unsigned int* d_keys_extract;
     unsigned int* d_tile_offsets;
     unsigned int* d_unique_out;
     unsigned int* d_counts_out;
     unsigned int* d_run_offsets;
     unsigned int* d_num_runs;
-    void* d_temp_sort;
-    size_t temp_sort_bytes;
+    void* d_temp_sort64;
+    size_t temp_sort64_bytes;
     void* d_temp_rle;
     size_t temp_rle_bytes;
     void* d_temp_scan;
@@ -41,7 +41,7 @@ struct SphereBinningResources {
     int totalTiles;
 };
 
-void initSphereBinningResources(SphereBinningResources* r, int maxSpheres, int tilesX, int tilesY, int totalTiles);
+void initSphereBinningResources(SphereBinningResources* r, int maxSpheres, int tilesX, int tilesY, int totalTiles, int avgEntitiesPerTile = 0);
 void freeSphereBinningResources(SphereBinningResources* r);
 void resetSphereBinningCounters(SphereBinningResources* r, cudaStream_t stream);
 

--- a/kernels/hybrid_binning/sphere_pipeline_binning.cuh
+++ b/kernels/hybrid_binning/sphere_pipeline_binning.cuh
@@ -21,8 +21,6 @@ struct SphereBinningResources {
     /** Sorted 64-bit pairs (output of radix sort) */
     unsigned long long* d_tile_entity_pairs_sorted;
     unsigned int* d_pairCount;
-    /** Temp: tile_id per element for RLE input (extracted from 64-bit pairs) */
-    unsigned int* d_keys_extract;
     unsigned int* d_tile_offsets;
     unsigned int* d_unique_out;
     unsigned int* d_counts_out;

--- a/kernels/hybrid_binning/sphere_pipeline_binning.cuh
+++ b/kernels/hybrid_binning/sphere_pipeline_binning.cuh
@@ -37,6 +37,7 @@ struct SphereBinningResources {
     int tilesX;
     int tilesY;
     int totalTiles;
+    unsigned int* d_tileClassifyCounts; // [0]=lightCount, [1]=heavyCount
 };
 
 void initSphereBinningResources(SphereBinningResources* r, int maxSpheres, int tilesX, int tilesY, int totalTiles, int avgEntitiesPerTile = 0);

--- a/kernels/hybrid_binning/sphere_pipeline_binning.cuh
+++ b/kernels/hybrid_binning/sphere_pipeline_binning.cuh
@@ -1,0 +1,59 @@
+/**
+ * @file sphere_pipeline_binning.cuh
+ * @brief Sphere pipeline for binning-by-sort (Generate -> Sort -> RLE -> tileOffsets -> tiled raster).
+ */
+
+#ifndef SPHERE_PIPELINE_BINNING_CUH
+#define SPHERE_PIPELINE_BINNING_CUH
+
+#include <cuda_runtime.h>
+#include "hybrid_binning_types.h"
+
+struct SphereBinningResources {
+    unsigned int* d_smallIndices;
+    unsigned int* d_smallCount;
+    unsigned int* d_largeCount;
+    SphereBillboard* d_largeBillboards;
+    unsigned int* d_frustumPassedCount;
+    unsigned int* h_smallCount;
+    unsigned int* h_largeCount;
+    unsigned int* h_frustumPassedCount;
+    unsigned int* d_pairCount;
+    unsigned int* d_keys_in;
+    unsigned int* d_values_in;
+    unsigned int* d_keys_out;
+    unsigned int* d_values_out;
+    unsigned int* d_tile_offsets;
+    unsigned int* d_unique_out;
+    unsigned int* d_counts_out;
+    unsigned int* d_run_offsets;
+    unsigned int* d_num_runs;
+    void* d_temp_sort;
+    size_t temp_sort_bytes;
+    void* d_temp_rle;
+    size_t temp_rle_bytes;
+    void* d_temp_scan;
+    size_t temp_scan_bytes;
+    int maxSpheres;
+    int maxPairs;
+    int tilesX;
+    int tilesY;
+    int totalTiles;
+};
+
+void initSphereBinningResources(SphereBinningResources* r, int maxSpheres, int tilesX, int tilesY, int totalTiles);
+void freeSphereBinningResources(SphereBinningResources* r);
+void resetSphereBinningCounters(SphereBinningResources* r, cudaStream_t stream);
+
+void executeSpherePipelineBinning(
+    const glm::vec4* d_spheres,
+    int sphereCount,
+    unsigned int* d_depthBuffer,
+    cudaSurfaceObject_t outputImage,
+    SphereBinningResources* r,
+    cudaStream_t stream);
+
+void getSphereBinningStats(SphereBinningResources* r,
+    unsigned int* outFrustumPassed, unsigned int* outSmallCount, unsigned int* outLargeCount);
+
+#endif

--- a/kernels/hybrid_binning/sphere_pipeline_binning.cuh
+++ b/kernels/hybrid_binning/sphere_pipeline_binning.cuh
@@ -37,7 +37,13 @@ struct SphereBinningResources {
     int tilesX;
     int tilesY;
     int totalTiles;
-    unsigned int* d_tileClassifyCounts; // [0]=lightCount, [1]=heavyCount
+    // Work-group expansion buffers
+    unsigned int* d_wg_tileId;       ///< tile index for each work group
+    unsigned int* d_wg_entityStart;  ///< start offset in sorted pairs for each WG
+    unsigned int* d_wg_entityCount;  ///< entity count per WG (≤ SHARED_BATCH_SIZE)
+    unsigned int* d_wg_totalCount;   ///< single uint: atomicAdd counter for total WGs
+    unsigned int* h_wg_totalCount;   ///< pinned host copy of total WG count
+    int maxWorkGroups;               ///< allocated size of WG arrays
 };
 
 void initSphereBinningResources(SphereBinningResources* r, int maxSpheres, int tilesX, int tilesY, int totalTiles, int avgEntitiesPerTile = 0);

--- a/kernels/hybrid_binning/tiled_raster_binning.cu
+++ b/kernels/hybrid_binning/tiled_raster_binning.cu
@@ -202,7 +202,6 @@ __global__ void tiledCylinderRasterBinningKernel(
     if (entityCount == 0) return;
 
     __shared__ glm::vec4 shPa[SHARED_BATCH], shPb[SHARED_BATCH];
-    __shared__ glm::vec2 shQuad[SHARED_BATCH * 4];
 
     float aspectRatio = (float)hybridCst.screenWidth / (float)hybridCst.screenHeight;
     float fovRad = glm::radians(hybridCst.fov);

--- a/kernels/hybrid_binning/tiled_raster_binning.cu
+++ b/kernels/hybrid_binning/tiled_raster_binning.cu
@@ -34,45 +34,52 @@ __device__ inline glm::vec3 computeRayDirTiled(int px, int py, float fovTan, flo
 }
 
 __device__ inline void computeSphereBBoxTiled(const glm::vec4& spherePosR,
-    int& bboxMinX, int& bboxMinY, int& bboxMaxX, int& bboxMaxY) {
-    glm::vec4 camSpace4 = hybridCst.view * glm::vec4(glm::vec3(spherePosR), 1.0f);
+    int& bboxMinX, int& bboxMinY, int& bboxMaxX, int& bboxMaxY) 
+{
+    glm::vec3 spherePos = glm::vec3(spherePosR);
+    float radius = spherePosR.w;
+    glm::vec4 camSpace4 = hybridCst.view * glm::vec4(spherePos, 1.0f);
     glm::vec3 cameraSpaceSphere = glm::vec3(camSpace4);
     glm::vec3 normCamSpaceSphere = glm::normalize(cameraSpaceSphere);
-    glm::vec3 camImposPos = cameraSpaceSphere - normCamSpaceSphere * spherePosR.w;
+    glm::vec3 camImposPos = cameraSpaceSphere - normCamSpaceSphere * radius;
+
     float dist = glm::length(cameraSpaceSphere) + 1e-6f;
-    float sinAngle = spherePosR.w / dist;
+    float sinAngle = __fdividef(radius, dist);
     float tanAngle = tanf(asinf(fminf(sinAngle, 0.999f)));
     float quadScale = tanAngle * glm::length(camImposPos);
+
     glm::vec3 upVec(0.0f, 1.0f, 0.0f);
     glm::vec3 impU = glm::normalize(glm::cross(normCamSpaceSphere, upVec));
     if (glm::length(impU) < 0.001f) impU = glm::vec3(1.0f, 0.0f, 0.0f);
     glm::vec3 impV = glm::cross(impU, normCamSpaceSphere) * quadScale;
     impU *= quadScale;
+
     glm::vec3 corners[4] = {
         camImposPos + impU + impV, camImposPos - impU + impV,
         camImposPos + impU - impV, camImposPos - impU - impV
     };
-    float minCx = 1e6f, minCy = 1e6f, maxCx = -1e6f, maxCy = -1e6f;
+
+    glm::vec2 minC(1e6f), maxC(-1e6f);
+    #pragma unroll
     for (int i = 0; i < 4; i++) {
         glm::vec4 clip = hybridCst.proj * glm::vec4(corners[i], 1.0f);
-        float iw = 1.0f / clip.w;
-        float x = clip.x * iw, y = clip.y * iw;
-        minCx = fminf(minCx, x); minCy = fminf(minCy, y);
-        maxCx = fmaxf(maxCx, x); maxCy = fmaxf(maxCy, y);
+        float iw = __fdividef(1.0f, clip.w);
+        float x = clip.x * iw;
+        float y = clip.y * iw;
+        minC.x = fminf(minC.x, x); minC.y = fminf(minC.y, y);
+        maxC.x = fmaxf(maxC.x, x); maxC.y = fmaxf(maxC.y, y);
     }
-    bboxMinX = (int)floorf((minCx * 0.5f + 0.5f) * hybridCst.screenWidth);
-    bboxMinY = (int)floorf((minCy * 0.5f + 0.5f) * hybridCst.screenHeight);
-    bboxMaxX = (int)ceilf((maxCx * 0.5f + 0.5f) * hybridCst.screenWidth);
-    bboxMaxY = (int)ceilf((maxCy * 0.5f + 0.5f) * hybridCst.screenHeight);
-    bboxMinX = max(0, bboxMinX); bboxMinY = max(0, bboxMinY);
-    bboxMaxX = min(hybridCst.screenWidth, bboxMaxX);
-    bboxMaxY = min(hybridCst.screenHeight, bboxMaxY);
+
+    bboxMinX = __float2int_rd(fmaf(minC.x, 0.5f, 0.5f) * hybridCst.screenWidth);
+    bboxMinY = __float2int_rd(fmaf(minC.y, 0.5f, 0.5f) * hybridCst.screenHeight);
+    bboxMaxX = __float2int_ru(fmaf(maxC.x, 0.5f, 0.5f) * hybridCst.screenWidth);
+    bboxMaxY = __float2int_ru(fmaf(maxC.y, 0.5f, 0.5f) * hybridCst.screenHeight);
 }
 
 __global__ void tiledSphereRasterBinningKernel(
     const glm::vec4* __restrict__ d_spheres,
     const unsigned int* __restrict__ d_tile_offsets,
-    const unsigned int* __restrict__ d_sorted_entity_indices,
+    const unsigned long long* __restrict__ d_tile_entity_pairs_sorted,
     unsigned int* __restrict__ depthBuffer,
     cudaSurfaceObject_t outputImage)
 {
@@ -96,8 +103,9 @@ __global__ void tiledSphereRasterBinningKernel(
     float fovRad = glm::radians(hybridCst.fov);
     float fovTan = tanf(fovRad * 0.5f);
     float halfFovTan = fovTan * aspectRatio;
+
     glm::vec3 rd = computeRayDirTiled(pixelX, pixelY, fovTan, halfFovTan);
-    float minDepth = 1e10f;
+    float minDepth = depthBuffer[pixelY * hybridCst.screenWidth + pixelX];
     glm::vec3 finalColor(0.0f);
     bool hasHit = false;
 
@@ -108,7 +116,8 @@ __global__ void tiledSphereRasterBinningKernel(
         if (localIdx < SHARED_BATCH) {
             unsigned int entityIdx = batchStart + localIdx;
             if (entityIdx < entityCount) {
-                unsigned int sphereIndex = d_sorted_entity_indices[entityStart + entityIdx];
+                unsigned long long pair = d_tile_entity_pairs_sorted[entityStart + entityIdx];
+                unsigned int sphereIndex = (unsigned int)(pair & 0xFFFFFFFFu);
                 glm::vec4 posR = d_spheres[sphereIndex];
                 shPosR[localIdx] = posR;
                 int bx0, by0, bx1, by1;
@@ -127,14 +136,15 @@ __global__ void tiledSphereRasterBinningKernel(
             float t = iSphereTiled(hybridCst.cameraPos, rd, glm::vec3(posR), posR.w);
             if (t > 0.0f) {
                 glm::vec3 hit = hybridCst.cameraPos + rd * t;
-                glm::vec4 hitClip = hybridCst.proj * (hybridCst.view * glm::vec4(hit, 1.0f));
-                float depth = hitClip.z / hitClip.w;
+                float proj22 = hybridCst.proj[2][2];
+                float proj32 = hybridCst.proj[3][2];
+                float depth = __fdividef(fmaf(hit.z, proj22, proj32), -hit.z);
                 if (depth < minDepth) {
                     minDepth = depth;
                     hasHit = true;
                     glm::vec3 normal = glm::normalize(hit - glm::vec3(posR));
-                    float lambert = fmaxf(0.0f, glm::dot(normal, -glm::normalize(rd)));
-                    finalColor = glm::vec3(0.01f, 1.0f, 0.05f) * lambert * 0.9f;
+                    float lambert = fmaxf(0.0f, glm::dot(normal, -glm::normalize(rd * t)));
+                    finalColor = glm::vec3(atomsColor[0], atomsColor[1], atomsColor[2]) * lambert * diffuse;
                 }
             }
         }
@@ -144,30 +154,51 @@ __global__ void tiledSphereRasterBinningKernel(
     if (hasHit) {
         int pixelIdx = pixelY * hybridCst.screenWidth + pixelX;
         unsigned int depthU = __float_as_uint(minDepth);
-        unsigned int old = atomicMin(&depthBuffer[pixelIdx], depthU);
-        if (__uint_as_float(old) > minDepth) {
-            uchar4 pixel = make_uchar4(
-                (unsigned char)(finalColor.x * 255.0f),
-                (unsigned char)(finalColor.y * 255.0f),
-                (unsigned char)(finalColor.z * 255.0f), 255);
-            surf2Dwrite(pixel, outputImage, pixelX * sizeof(uchar4), pixelY);
-        }
+        depthBuffer[pixelIdx] = depthU;
+        uchar4 pixel = make_uchar4(
+            (unsigned char)(finalColor.x * 255.0f),
+            (unsigned char)(finalColor.y * 255.0f),
+            (unsigned char)(finalColor.z * 255.0f), 255);
+        surf2Dwrite(pixel, outputImage, pixelX * sizeof(uchar4), pixelY);
+        
     }
+}
+
+
+// Cross product of 2D vectors
+__device__ inline float cross2D(glm::vec2 a, glm::vec2 b) 
+{
+    return a.x * b.y - a.y * b.x;
+}
+
+// Check if point is inside convex quadrilateral
+__device__ inline bool pointInQuad(glm::vec2 p, glm::vec2 q0, glm::vec2 q1, glm::vec2 q2, glm::vec2 q3) 
+{
+    float c0 = cross2D(q1 - q0, p - q0);
+    float c1 = cross2D(q2 - q1, p - q1);
+    float c2 = cross2D(q3 - q2, p - q2);
+    float c3 = cross2D(q0 - q3, p - q3);
+    
+    return (c0 >= 0 && c1 >= 0 && c2 >= 0 && c3 >= 0) ||
+           (c0 <= 0 && c1 <= 0 && c2 <= 0 && c3 <= 0);
 }
 
 // Cylinder: ray-cylinder and bbox from quad (simplified - reuse logic from hybrid tiled)
 __device__ inline glm::vec4 iCylinderTiled(const glm::vec3& ro, const glm::vec3& rd,
-    const glm::vec3& pa, const glm::vec3& pb, float ra) {
+    const glm::vec3& pa, const glm::vec3& pb, float ra) 
+    {
     glm::vec3 ba = pb - pa, oc = ro - pa;
     float baba = glm::dot(ba, ba), bard = glm::dot(ba, rd), baoc = glm::dot(ba, oc);
-    float k2 = baba - bard * bard;
-    float k1 = baba * glm::dot(oc, rd) - baoc * bard;
-    float k0 = baba * glm::dot(oc, oc) - baoc * baoc - ra * ra * baba;
-    float h = k1 * k1 - k2 * k0;
+    
+    float k2 = fmaf(bard, -bard, baba);
+    float k1 = fmaf(glm::dot(oc,rd), baba, -baoc*bard);
+    float k0 = fmaf(baba, glm::dot(oc,oc), fmaf(- ra*ra, baba, -baoc*baoc));
+    
+    float h = fmaf(k1, k1, -k2*k0);
     if (h < 0.0f) return glm::vec4(-1.0f);
     h = sqrtf(h);
     float t = (-k1 - h) / k2;
-    float y = baoc + t * bard;
+    float y = fmaf(t, bard, baoc);
     if (y > 0.0f && y < baba) return glm::vec4(t, oc + t * rd - ba * y / baba);
     return glm::vec4(-1.0f);
 }
@@ -175,7 +206,7 @@ __device__ inline glm::vec4 iCylinderTiled(const glm::vec3& ro, const glm::vec3&
 __global__ void tiledCylinderRasterBinningKernel(
     const Cylinder* __restrict__ d_cylinders,
     const unsigned int* __restrict__ d_tile_offsets,
-    const unsigned int* __restrict__ d_sorted_entity_indices,
+    const unsigned long long* __restrict__ d_tile_entity_pairs_sorted,
     unsigned int* __restrict__ depthBuffer,
     cudaSurfaceObject_t outputImage)
 {
@@ -199,7 +230,7 @@ __global__ void tiledCylinderRasterBinningKernel(
     float fovTan = tanf(fovRad * 0.5f);
     float halfFovTan = fovTan * aspectRatio;
     glm::vec3 rd = computeRayDirTiled(pixelX, pixelY, fovTan, halfFovTan);
-    float minDepth = 1e10f;
+    float minDepth = depthBuffer[pixelY * hybridCst.screenWidth + pixelX];
     glm::vec3 finalColor(0.0f);
     bool hasHit = false;
 
@@ -210,33 +241,67 @@ __global__ void tiledCylinderRasterBinningKernel(
         if (localIdx < SHARED_BATCH) {
             unsigned int entityIdx = batchStart + localIdx;
             if (entityIdx < entityCount) {
-                unsigned int cylIndex = d_sorted_entity_indices[entityStart + entityIdx];
+                unsigned long long pair = d_tile_entity_pairs_sorted[entityStart + entityIdx];
+                unsigned int cylIndex = (unsigned int)(pair & 0xFFFFFFFFu);
                 Cylinder cyl = d_cylinders[cylIndex];
                 shPa[localIdx] = cyl.pa_r;
                 shPb[localIdx] = cyl.pb_r;
+
                 glm::vec3 pa = glm::vec3(cyl.pa_r), pb = glm::vec3(cyl.pb_r);
                 float radius = cyl.pa_r.w;
                 glm::vec4 camA = hybridCst.view * glm::vec4(pa, 1.0f);
                 glm::vec4 camB = hybridCst.view * glm::vec4(pb, 1.0f);
-                glm::vec3 camImpPosA = glm::vec3(camA), camImpPosB = glm::vec3(camB);
-                if (camImpPosA.z > camImpPosB.z) { glm::vec3 tmp = camImpPosA; camImpPosA = camImpPosB; camImpPosB = tmp; }
-                glm::vec3 z = glm::normalize(camImpPosB - camImpPosA);
-                glm::vec3 center = glm::normalize((camImpPosA + camImpPosB) * 0.5f);
-                glm::vec3 x = glm::normalize(glm::cross(center, z));
-                glm::vec3 y = glm::normalize(glm::cross(x, z));
-                float dV0 = glm::length(camImpPosA), dV1 = glm::length(camImpPosB);
-                float sinA0 = radius / dV0, sinA1 = radius / dV1;
-                float angle0 = asinf(fminf(sinA0, 0.999f)), angle1 = asinf(fminf(sinA1, 0.999f));
-                glm::vec3 v1 = camImpPosA - x * (radius * cosf(angle0)) + y * (radius * sinA0);
-                glm::vec3 v2 = camImpPosA + x * (radius * cosf(angle0)) + y * (radius * sinA0);
-                glm::vec3 v3 = camImpPosB - x * (float)(dV1 - radius) * tanf(angle1) + y * radius;
-                glm::vec3 v4 = camImpPosB + x * (float)(dV1 - radius) * tanf(angle1) + y * radius;
-                for (int k = 0; k < 4; k++) {
-                    glm::vec3 v = (k == 0) ? v1 : (k == 1) ? v2 : (k == 2) ? v4 : v3;
-                    glm::vec4 clip = hybridCst.proj * glm::vec4(v, 1.0f);
-                    glm::vec2 ndc = glm::vec2(clip.x / clip.w, clip.y / clip.w);
-                    shQuad[localIdx * 4 + k] = (ndc * 0.5f + 0.5f) * glm::vec2(hybridCst.screenWidth, hybridCst.screenHeight);
+                glm::vec3 camImpPosA, camImpPosB;
+                if ( camA.z < camB.z )
+                {
+                    camImpPosA = glm::vec3(camB);
+                    camImpPosB = glm::vec3(camA);
                 }
+                else
+                {
+                    camImpPosA = glm::vec3(camA);
+                    camImpPosB = glm::vec3(camB);
+                }
+                glm::vec3 center = glm::normalize( ( camImpPosA + camImpPosB ) * 0.5f );
+                // Cylinder axis
+                const glm::vec3 z = glm::normalize(camImpPosB - camImpPosA);
+
+                // Find orthonormal x,y axes orthogonal to cylinder axis
+                glm::vec3 x = glm::normalize(glm::cross(center, z));
+                glm::vec3 y = glm::normalize(glm::cross(x, z)); // make full basis
+
+                // Compute impostor construction vectors.
+                const float dV0 = glm::length( camImpPosA );
+                const float dV1 = glm::length( camImpPosB );
+
+                const float sinAngle = __fdividef(radius, dV0);
+                float		angle	 = asinf( sinAngle );
+                const glm::vec3	y1		 = y * radius;
+                const glm::vec3	x2		 = x * radius * cosf( angle );
+                const glm::vec3	y2		 = y1 * sinAngle;
+                angle				 = asinf( __fdividef(radius, dV1) );
+                const glm::vec3 x3		 = x * ( dV1 - radius ) * __tanf( angle );
+
+                // Compute impostors vertices.
+                const glm::vec3 v1 = camImpPosA - x2 + y2;
+                const glm::vec3 v2 = camImpPosA + x2 + y2;
+                const glm::vec3 v3 = camImpPosB - x3 + y1;
+                const glm::vec3 v4 = camImpPosB + x3 + y1;
+
+                const glm::vec4 v1Proj = hybridCst.proj * glm::vec4(v1, 1.0f);
+                const glm::vec4 v2Proj = hybridCst.proj * glm::vec4(v2, 1.0f);
+                const glm::vec4 v3Proj = hybridCst.proj * glm::vec4(v3, 1.0f);
+                const glm::vec4 v4Proj = hybridCst.proj * glm::vec4(v4, 1.0f);
+
+                glm::vec3 ndcv1Proj = glm::vec3(__fdividef(v1Proj.x, v1Proj.w), __fdividef(v1Proj.y, v1Proj.w), __fdividef(v1Proj.z, v1Proj.w));
+                glm::vec3 ndcv2Proj = glm::vec3(__fdividef(v2Proj.x, v2Proj.w), __fdividef(v2Proj.y, v2Proj.w), __fdividef(v2Proj.z, v2Proj.w));
+                glm::vec3 ndcv3Proj = glm::vec3(__fdividef(v3Proj.x, v3Proj.w), __fdividef(v3Proj.y, v3Proj.w), __fdividef(v3Proj.z, v3Proj.w));
+                glm::vec3 ndcv4Proj = glm::vec3(__fdividef(v4Proj.x, v4Proj.w), __fdividef(v4Proj.y, v4Proj.w), __fdividef(v4Proj.z, v4Proj.w));
+
+                shQuad[localIdx * 4 + 0] = glm::vec2(ndcv1Proj);
+                shQuad[localIdx * 4 + 1] = glm::vec2(ndcv2Proj);
+                shQuad[localIdx * 4 + 2] = glm::vec2(ndcv4Proj);
+                shQuad[localIdx * 4 + 3] = glm::vec2(ndcv3Proj);
             }
         }
         __syncthreads();
@@ -246,25 +311,22 @@ __global__ void tiledCylinderRasterBinningKernel(
         for (unsigned int i = 0; i < batchCount; i++) {
             glm::vec2 q0 = shQuad[i * 4 + 0], q1 = shQuad[i * 4 + 1];
             glm::vec2 q2 = shQuad[i * 4 + 2], q3 = shQuad[i * 4 + 3];
-            float c0 = (q1.x - q0.x) * (pixelCenter.y - q0.y) - (q1.y - q0.y) * (pixelCenter.x - q0.x);
-            float c1 = (q2.x - q1.x) * (pixelCenter.y - q1.y) - (q2.y - q1.y) * (pixelCenter.x - q1.x);
-            float c2 = (q3.x - q2.x) * (pixelCenter.y - q2.y) - (q3.y - q2.y) * (pixelCenter.x - q2.x);
-            float c3 = (q0.x - q3.x) * (pixelCenter.y - q3.y) - (q0.y - q3.y) * (pixelCenter.x - q3.x);
-            bool inside = (c0 >= 0 && c1 >= 0 && c2 >= 0 && c3 >= 0) || (c0 <= 0 && c1 <= 0 && c2 <= 0 && c3 <= 0);
-            if (!inside) continue;
+            
+            if (!pointInQuad(pixelCenter, q0, q1, q2, q3)) continue;
             glm::vec3 pa = glm::vec3(shPa[i]), pb = glm::vec3(shPb[i]);
             float ra = shPa[i].w;
             glm::vec4 tnor = iCylinderTiled(hybridCst.cameraPos, rd, pa, pb, ra);
             if (tnor.x > 0.0f) {
-                glm::vec3 hit = hybridCst.cameraPos + rd * tnor.x;
-                glm::vec4 hitClip = hybridCst.proj * (hybridCst.view * glm::vec4(hit, 1.0f));
-                float depth = hitClip.z / hitClip.w;
+                float t = tnor.x;
+                glm::vec3 hit = hybridCst.cameraPos + rd * t;
+                float depth = __fdividef(fmaf(hit.z, hybridCst.proj[2][2], hybridCst.proj[3][2]), -hit.z);
+
                 if (depth < minDepth) {
                     minDepth = depth;
                     hasHit = true;
-                    glm::vec3 normal = glm::normalize(tnor.yzw);
-                    float lambert = fmaxf(0.0f, glm::dot(normal, -glm::normalize(rd)));
-                    finalColor = glm::vec3(0.01f, 1.0f, 0.05f) * lambert * 0.9f;
+                    glm::vec3 normal = glm::normalize(glm::vec3(tnor.y, tnor.z, tnor.w));
+                    float lambert = glm::max(0.0f, glm::dot(normal, -glm::normalize(rd * t)));
+                    finalColor = glm::vec3(bondsColor[0], bondsColor[1], bondsColor[2]) * lambert * diffuse;
                 }
             }
         }
@@ -274,21 +336,19 @@ __global__ void tiledCylinderRasterBinningKernel(
     if (hasHit) {
         int pixelIdx = pixelY * hybridCst.screenWidth + pixelX;
         unsigned int depthU = __float_as_uint(minDepth);
-        unsigned int old = atomicMin(&depthBuffer[pixelIdx], depthU);
-        if (__uint_as_float(old) > minDepth) {
-            uchar4 pixel = make_uchar4(
-                (unsigned char)(finalColor.x * 255.0f),
-                (unsigned char)(finalColor.y * 255.0f),
-                (unsigned char)(finalColor.z * 255.0f), 255);
-            surf2Dwrite(pixel, outputImage, pixelX * sizeof(uchar4), pixelY);
-        }
+        depthBuffer[pixelIdx] = depthU;
+        uchar4 pixel = make_uchar4(
+            (unsigned char)(finalColor.x * 255.0f),
+            (unsigned char)(finalColor.y * 255.0f),
+            (unsigned char)(finalColor.z * 255.0f), 255);
+        surf2Dwrite(pixel, outputImage, pixelX * sizeof(uchar4), pixelY);
     }
 }
 
 extern "C" void launchTiledSphereRasterBinning(
     const glm::vec4* d_spheres,
     const unsigned int* d_tile_offsets,
-    const unsigned int* d_sorted_entity_indices,
+    const unsigned long long* d_tile_entity_pairs_sorted,
     unsigned int* d_depthBuffer,
     cudaSurfaceObject_t outputImage,
     unsigned int tilesX,
@@ -298,13 +358,13 @@ extern "C" void launchTiledSphereRasterBinning(
     dim3 block(TILE_SIZE, TILE_SIZE);
     dim3 grid(tilesX, tilesY);
     tiledSphereRasterBinningKernel<<<grid, block, 0, stream>>>(
-        d_spheres, d_tile_offsets, d_sorted_entity_indices, d_depthBuffer, outputImage);
+        d_spheres, d_tile_offsets, d_tile_entity_pairs_sorted, d_depthBuffer, outputImage);
 }
 
 extern "C" void launchTiledCylinderRasterBinning(
     const Cylinder* d_cylinders,
     const unsigned int* d_tile_offsets,
-    const unsigned int* d_sorted_entity_indices,
+    const unsigned long long* d_tile_entity_pairs_sorted,
     unsigned int* d_depthBuffer,
     cudaSurfaceObject_t outputImage,
     unsigned int tilesX,
@@ -314,5 +374,5 @@ extern "C" void launchTiledCylinderRasterBinning(
     dim3 block(TILE_SIZE, TILE_SIZE);
     dim3 grid(tilesX, tilesY);
     tiledCylinderRasterBinningKernel<<<grid, block, 0, stream>>>(
-        d_cylinders, d_tile_offsets, d_sorted_entity_indices, d_depthBuffer, outputImage);
+        d_cylinders, d_tile_offsets, d_tile_entity_pairs_sorted, d_depthBuffer, outputImage);
 }

--- a/kernels/hybrid_binning/tiled_raster_binning.cu
+++ b/kernels/hybrid_binning/tiled_raster_binning.cu
@@ -1,7 +1,9 @@
-/**
+﻿/**
  * @file tiled_raster_binning.cu
- * @brief Tiled rasterization using tileOffsets + sorted entity indices (no billboards).
- * Loads sphere/cylinder data from original buffers; recomputes bbox in shared memory.
+ * @brief Work-group expansion from RLE + unified tiled rasterization.
+ * After sort+RLE, each tile's entities are split into work groups of SHARED_BATCH.
+ * Each CUDA block processes one work group: loads entities into shared memory,
+ * ray-traces, and uses atomicMin on the depth buffer.
  */
 
 #include <cuda_runtime.h>
@@ -14,14 +16,8 @@ extern __constant__ HybridConstants hybridCst;
 
 #define TILE_SIZE 16
 #define SHARED_BATCH 64
-#define HEAVY_TILE_THRESHOLD 256
 
-/** Work-stealing counters for persistent-thread bin-split kernels.
- *  g_nextLightWorkItem: index into the compact light-tile list.
- *  g_nextHeavyWorkItem: index into the expanded heavy work-item list.
- *  Must be reset to 0 before each kernel launch. */
-__device__ unsigned int g_nextLightWorkItem;
-__device__ unsigned int g_nextHeavyWorkItem;
+// ─────────── Helpers ───────────
 
 __device__ inline float iSphereTiled(const glm::vec3& ro, const glm::vec3& rd,
                                      const glm::vec3& center, float radius) {
@@ -40,302 +36,16 @@ __device__ inline glm::vec3 computeRayDirTiled(int px, int py, float fovTan, flo
                           p.y * hybridCst.up * fovTan + hybridCst.front);
 }
 
-__device__ inline void computeSphereBBoxTiled(const glm::vec4& spherePosR,
-    int& bboxMinX, int& bboxMinY, int& bboxMaxX, int& bboxMaxY) 
-{
-    glm::vec3 spherePos = glm::vec3(spherePosR);
-    float radius = spherePosR.w;
-    glm::vec4 camSpace4 = hybridCst.view * glm::vec4(spherePos, 1.0f);
-    glm::vec3 cameraSpaceSphere = glm::vec3(camSpace4);
-    glm::vec3 normCamSpaceSphere = glm::normalize(cameraSpaceSphere);
-    glm::vec3 camImposPos = cameraSpaceSphere - normCamSpaceSphere * radius;
-
-    float dist = glm::length(cameraSpaceSphere) + 1e-6f;
-    float sinAngle = __fdividef(radius, dist);
-    float tanAngle = tanf(asinf(fminf(sinAngle, 0.999f)));
-    float quadScale = tanAngle * glm::length(camImposPos);
-
-    glm::vec3 upVec(0.0f, 1.0f, 0.0f);
-    glm::vec3 impU = glm::normalize(glm::cross(normCamSpaceSphere, upVec));
-    if (glm::length(impU) < 0.001f) impU = glm::vec3(1.0f, 0.0f, 0.0f);
-    glm::vec3 impV = glm::cross(impU, normCamSpaceSphere) * quadScale;
-    impU *= quadScale;
-
-    glm::vec3 corners[4] = {
-        camImposPos + impU + impV, camImposPos - impU + impV,
-        camImposPos + impU - impV, camImposPos - impU - impV
-    };
-
-    glm::vec2 minC(1e6f), maxC(-1e6f);
-    #pragma unroll
-    for (int i = 0; i < 4; i++) {
-        glm::vec4 clip = hybridCst.proj * glm::vec4(corners[i], 1.0f);
-        float iw = __fdividef(1.0f, clip.w);
-        float x = clip.x * iw;
-        float y = clip.y * iw;
-        minC.x = fminf(minC.x, x); minC.y = fminf(minC.y, y);
-        maxC.x = fmaxf(maxC.x, x); maxC.y = fmaxf(maxC.y, y);
-    }
-
-    bboxMinX = __float2int_rd(fmaf(minC.x, 0.5f, 0.5f) * hybridCst.screenWidth);
-    bboxMinY = __float2int_rd(fmaf(minC.y, 0.5f, 0.5f) * hybridCst.screenHeight);
-    bboxMaxX = __float2int_ru(fmaf(maxC.x, 0.5f, 0.5f) * hybridCst.screenWidth);
-    bboxMaxY = __float2int_ru(fmaf(maxC.y, 0.5f, 0.5f) * hybridCst.screenHeight);
-}
-
-/** Classify tiles into light (single-block) and heavy (multi-block) lists.
- *  - Empty tiles: skipped.
- *  - Light tiles (entityCount in (0, HEAVY_TILE_THRESHOLD]): 1 entry in d_lightTileList.
- *  - Heavy tiles (entityCount > HEAVY_TILE_THRESHOLD): ceil(entityCount/SHARED_BATCH)
- *    work-items in d_heavyTileIndices + d_heavyBatchStarts.
- *  d_tileClassifyCounts[0] = total light tiles, [1] = total heavy work items. */
-__global__ void classifyTilesKernel(
-    const unsigned int* __restrict__ d_tile_offsets,
-    unsigned int* __restrict__ d_lightTileList,
-    unsigned int* __restrict__ d_heavyTileIndices,
-    unsigned int* __restrict__ d_heavyBatchStarts,
-    unsigned int* __restrict__ d_tileClassifyCounts,
-    unsigned int totalTiles)
-{
-    unsigned int tid = blockIdx.x * blockDim.x + threadIdx.x;
-    if (tid >= totalTiles) return;
-    unsigned int entityCount = d_tile_offsets[tid + 1] - d_tile_offsets[tid];
-    if (entityCount == 0) return;
-
-    if (entityCount <= HEAVY_TILE_THRESHOLD) {
-        unsigned int idx = atomicAdd(&d_tileClassifyCounts[0], 1u);
-        d_lightTileList[idx] = tid;
-    } else {
-        unsigned int numBatches = (entityCount + SHARED_BATCH - 1) / SHARED_BATCH;
-        unsigned int base = atomicAdd(&d_tileClassifyCounts[1], numBatches);
-        for (unsigned int b = 0; b < numBatches; b++) {
-            d_heavyTileIndices[base + b] = tid;
-            d_heavyBatchStarts[base + b] = b * SHARED_BATCH;
-        }
-    }
-}
-
-/** Light sphere kernel: persistent threads, 1 tile per work-steal.
- *  Only ONE block ever processes a given tile, so no atomicMin needed. */
-__global__ void lightSphereRasterKernel(
-    const glm::vec4* __restrict__ d_spheres,
-    const unsigned int* __restrict__ d_tile_offsets,
-    const unsigned long long* __restrict__ d_tile_entity_pairs_sorted,
-    const unsigned int* __restrict__ d_lightTileList,
-    const unsigned int* __restrict__ d_tileClassifyCounts,
-    unsigned int* __restrict__ depthBuffer,
-    cudaSurfaceObject_t outputImage)
-{
-    const float aspectRatio = (float)hybridCst.screenWidth / (float)hybridCst.screenHeight;
-    const float fovRad = glm::radians(hybridCst.fov);
-    const float fovTan = tanf(fovRad * 0.5f);
-    const float halfFovTan = fovTan * aspectRatio;
-    const float proj22 = hybridCst.proj[2][2];
-    const float proj32 = hybridCst.proj[3][2];
-
-    __shared__ unsigned int s_workIdx;
-    __shared__ glm::vec4 shPosR[SHARED_BATCH];
-
-    const unsigned int totalLightTiles = d_tileClassifyCounts[0];
-
-    while (true) {
-        if (threadIdx.x == 0 && threadIdx.y == 0) {
-            s_workIdx = atomicAdd(&g_nextLightWorkItem, 1u);
-        }
-        __syncthreads();
-
-        if (s_workIdx >= totalLightTiles) return;
-
-        const unsigned int tileIdx = d_lightTileList[s_workIdx];
-        const unsigned int entityStart = d_tile_offsets[tileIdx];
-        const unsigned int entityEnd   = d_tile_offsets[tileIdx + 1];
-        const unsigned int entityCount = entityEnd - entityStart;
-
-        const unsigned int tileX = tileIdx % hybridCst.tilesX;
-        const unsigned int tileY = tileIdx / hybridCst.tilesX;
-        const int pixelX = tileX * TILE_SIZE + threadIdx.x;
-        const int pixelY = tileY * TILE_SIZE + threadIdx.y;
-        const bool validPixel = (pixelX < hybridCst.screenWidth && pixelY < hybridCst.screenHeight);
-
-        glm::vec3 rd, ray;
-        float minDepth = 1e30f;
-        if (validPixel) {
-            rd  = computeRayDirTiled(pixelX, pixelY, fovTan, halfFovTan);
-            ray = hybridCst.rayStart + (float)pixelX * hybridCst.dx + (float)pixelY * hybridCst.dy;
-            minDepth = __uint_as_float(depthBuffer[pixelY * hybridCst.screenWidth + pixelX]);
-        }
-        glm::vec3 finalColor(0.0f);
-        bool hasHit = false;
-
-        // Process ALL batches for this light tile within this single block
-        const unsigned int numBatches = (entityCount + SHARED_BATCH - 1) / SHARED_BATCH;
-        for (unsigned int batch = 0; batch < numBatches; batch++) {
-            unsigned int batchStart = batch * SHARED_BATCH;
-            unsigned int localIdx = threadIdx.y * TILE_SIZE + threadIdx.x;
-            if (localIdx < SHARED_BATCH) {
-                unsigned int entityIdx = batchStart + localIdx;
-                if (entityIdx < entityCount) {
-                    unsigned long long pair = d_tile_entity_pairs_sorted[entityStart + entityIdx];
-                    unsigned int sphereIndex = (unsigned int)(pair & 0xFFFFFFFFu);
-                    shPosR[localIdx] = d_spheres[sphereIndex];
-                }
-            }
-            __syncthreads();
-
-            if (validPixel) {
-                unsigned int batchCount = min(SHARED_BATCH, entityCount - batchStart);
-                for (unsigned int i = 0; i < batchCount; i++) {
-                    glm::vec4 posR = shPosR[i];
-                    float t = iSphereTiled(hybridCst.cameraPos, rd, glm::vec3(posR), posR.w);
-                    if (t > 0.0f) {
-                        glm::vec3 hit = ray * t;
-                        float depth = __fdividef(fmaf(hit.z, proj22, proj32), -hit.z);
-                        if (depth < minDepth) {
-                            minDepth = depth;
-                            hasHit = true;
-                            glm::vec3 worldHit = hybridCst.cameraPos + rd * t;
-                            glm::vec3 normal = glm::normalize(worldHit - glm::vec3(posR));
-                            float lambert = fmaxf(0.0f, glm::dot(normal, -glm::normalize(rd * t)));
-                            finalColor = glm::vec3(atomsColor[0], atomsColor[1], atomsColor[2]) * lambert * diffuse;
-                        }
-                    }
-                }
-            }
-            __syncthreads();
-        }
-
-        // Single block owns this tile — direct write, no atomicMin
-        if (validPixel && hasHit) {
-            int pixelIdx = pixelY * hybridCst.screenWidth + pixelX;
-            unsigned int depthU = __float_as_uint(minDepth);
-            depthBuffer[pixelIdx] = depthU;
-            uchar4 pixel = make_uchar4(
-                (unsigned char)(finalColor.x * 255.0f),
-                (unsigned char)(finalColor.y * 255.0f),
-                (unsigned char)(finalColor.z * 255.0f), 255);
-            surf2Dwrite(pixel, outputImage, pixelX * sizeof(uchar4), pixelY);
-        }
-        __syncthreads();
-    }
-}
-
-/** Heavy sphere kernel: persistent threads, 1 batch per work-steal.
- *  Multiple blocks may process the same tile -> atomicMin on depth buffer. */
-__global__ void heavySphereRasterKernel(
-    const glm::vec4* __restrict__ d_spheres,
-    const unsigned int* __restrict__ d_tile_offsets,
-    const unsigned long long* __restrict__ d_tile_entity_pairs_sorted,
-    const unsigned int* __restrict__ d_heavyTileIndices,
-    const unsigned int* __restrict__ d_heavyBatchStarts,
-    const unsigned int* __restrict__ d_tileClassifyCounts,
-    unsigned int* __restrict__ depthBuffer,
-    cudaSurfaceObject_t outputImage)
-{
-    const float aspectRatio = (float)hybridCst.screenWidth / (float)hybridCst.screenHeight;
-    const float fovRad = glm::radians(hybridCst.fov);
-    const float fovTan = tanf(fovRad * 0.5f);
-    const float halfFovTan = fovTan * aspectRatio;
-    const float proj22 = hybridCst.proj[2][2];
-    const float proj32 = hybridCst.proj[3][2];
-
-    __shared__ unsigned int s_workIdx;
-    __shared__ unsigned int s_tileIdx;
-    __shared__ unsigned int s_batchStart;
-    __shared__ unsigned int s_batchCount;
-    __shared__ glm::vec4 shPosR[SHARED_BATCH];
-
-    const unsigned int totalHeavyWorkItems = d_tileClassifyCounts[1];
-
-    while (true) {
-        if (threadIdx.x == 0 && threadIdx.y == 0) {
-            s_workIdx = atomicAdd(&g_nextHeavyWorkItem, 1u);
-        }
-        __syncthreads();
-
-        if (s_workIdx >= totalHeavyWorkItems) return;
-
-        // Decode which tile and which batch this work item represents
-        if (threadIdx.x == 0 && threadIdx.y == 0) {
-            unsigned int tileIdx = d_heavyTileIndices[s_workIdx];
-            unsigned int bStart  = d_heavyBatchStarts[s_workIdx];
-            unsigned int entityCount = d_tile_offsets[tileIdx + 1] - d_tile_offsets[tileIdx];
-            s_tileIdx    = tileIdx;
-            s_batchStart = bStart;
-            s_batchCount = min((unsigned int)SHARED_BATCH, entityCount - min(bStart, entityCount));
-        }
-        __syncthreads();
-
-        const unsigned int tileIdx    = s_tileIdx;
-        const unsigned int batchStart = s_batchStart;
-        const unsigned int batchCount = s_batchCount;
-
-        if (batchCount == 0) { __syncthreads(); continue; }
-
-        const unsigned int tileX = tileIdx % hybridCst.tilesX;
-        const unsigned int tileY = tileIdx / hybridCst.tilesX;
-        const int pixelX = tileX * TILE_SIZE + threadIdx.x;
-        const int pixelY = tileY * TILE_SIZE + threadIdx.y;
-        const bool validPixel = (pixelX < hybridCst.screenWidth && pixelY < hybridCst.screenHeight);
-
-        // Load one batch of entities into shared memory
-        const unsigned int entityStart = d_tile_offsets[tileIdx];
-        const unsigned int entityCount = d_tile_offsets[tileIdx + 1] - entityStart;
-        const unsigned int localIdx = threadIdx.y * TILE_SIZE + threadIdx.x;
-        if (localIdx < SHARED_BATCH) {
-            unsigned int entityIdx = batchStart + localIdx;
-            if (entityIdx < entityCount) {
-                unsigned long long pair = d_tile_entity_pairs_sorted[entityStart + entityIdx];
-                unsigned int sphereIndex = (unsigned int)(pair & 0xFFFFFFFFu);
-                shPosR[localIdx] = d_spheres[sphereIndex];
-            }
-        }
-        __syncthreads();
-
-        // Ray-trace this single batch; atomicMin for depth since multiple blocks share the tile
-        if (validPixel) {
-            glm::vec3 rd  = computeRayDirTiled(pixelX, pixelY, fovTan, halfFovTan);
-            glm::vec3 ray = hybridCst.rayStart + (float)pixelX * hybridCst.dx + (float)pixelY * hybridCst.dy;
-            const int pixelIdx = pixelY * hybridCst.screenWidth + pixelX;
-
-            for (unsigned int i = 0; i < batchCount; i++) {
-                glm::vec4 posR = shPosR[i];
-                float t = iSphereTiled(hybridCst.cameraPos, rd, glm::vec3(posR), posR.w);
-                if (t > 0.0f) {
-                    glm::vec3 hit = ray * t;
-                    float depth = __fdividef(fmaf(hit.z, proj22, proj32), -hit.z);
-                    unsigned int depthU = __float_as_uint(depth);
-                    unsigned int old = atomicMin(&depthBuffer[pixelIdx], depthU);
-                    if (depthU < old) {
-                        glm::vec3 worldHit = hybridCst.cameraPos + rd * t;
-                        glm::vec3 normal = glm::normalize(worldHit - glm::vec3(posR));
-                        float lambert = fmaxf(0.0f, glm::dot(normal, -glm::normalize(rd * t)));
-                        glm::vec3 color = glm::vec3(atomsColor[0], atomsColor[1], atomsColor[2]) * lambert * diffuse;
-                        uchar4 pixel = make_uchar4(
-                            (unsigned char)(color.x * 255.0f),
-                            (unsigned char)(color.y * 255.0f),
-                            (unsigned char)(color.z * 255.0f), 255);
-                        surf2Dwrite(pixel, outputImage, pixelX * sizeof(uchar4), pixelY);
-                    }
-                }
-            }
-        }
-        __syncthreads();
-    }
-}
-
-
-
-// Cylinder: ray-cylinder and bbox from quad (simplified - reuse logic from hybrid tiled)
 __device__ inline glm::vec4 iCylinderTiled(const glm::vec3& ro, const glm::vec3& rd,
-    const glm::vec3& pa, const glm::vec3& pb, float ra) 
-    {
+    const glm::vec3& pa, const glm::vec3& pb, float ra)
+{
     glm::vec3 ba = pb - pa, oc = ro - pa;
     float baba = glm::dot(ba, ba), bard = glm::dot(ba, rd), baoc = glm::dot(ba, oc);
-    
+
     float k2 = fmaf(bard, -bard, baba);
     float k1 = fmaf(glm::dot(oc,rd), baba, -baoc*bard);
     float k0 = fmaf(baba, glm::dot(oc,oc), fmaf(- ra*ra, baba, -baoc*baoc));
-    
+
     float h = fmaf(k1, k1, -k2*k0);
     if (h < 0.0f) return glm::vec4(-1.0f);
     h = sqrtf(h);
@@ -345,118 +55,76 @@ __device__ inline glm::vec4 iCylinderTiled(const glm::vec3& ro, const glm::vec3&
     return glm::vec4(-1.0f);
 }
 
-/** Light cylinder kernel: persistent threads, 1 tile per work-steal. No atomicMin. */
-__global__ void lightCylinderRasterKernel(
-    const Cylinder* __restrict__ d_cylinders,
-    const unsigned int* __restrict__ d_tile_offsets,
-    const unsigned long long* __restrict__ d_tile_entity_pairs_sorted,
-    const unsigned int* __restrict__ d_lightTileList,
-    const unsigned int* __restrict__ d_tileClassifyCounts,
-    unsigned int* __restrict__ depthBuffer,
-    cudaSurfaceObject_t outputImage)
+// ─────────── Work-group expansion from RLE results ───────────
+
+/**
+ * Expand RLE runs into a flat work-group dispatch list.
+ * Each RLE run i represents a tile with d_counts_out[i] entities starting
+ * at d_run_offsets[i] in the sorted pairs array.
+ * We split each run into ceil(count/SHARED_BATCH) work groups.
+ * Output: d_wg_tileId, d_wg_entityStart, d_wg_entityCount (one per WG).
+ * d_wg_totalCount is atomically incremented to give the total WG count.
+ */
+__global__ void expandWorkGroupsKernel(
+    const unsigned int* __restrict__ d_unique_out,
+    const unsigned int* __restrict__ d_counts_out,
+    const unsigned int* __restrict__ d_run_offsets,
+    unsigned int numRuns,
+    unsigned int* __restrict__ d_wg_tileId,
+    unsigned int* __restrict__ d_wg_entityStart,
+    unsigned int* __restrict__ d_wg_entityCount,
+    unsigned int* __restrict__ d_wg_totalCount)
 {
-    const float aspectRatio = (float)hybridCst.screenWidth / (float)hybridCst.screenHeight;
-    const float fovRad = glm::radians(hybridCst.fov);
-    const float fovTan = tanf(fovRad * 0.5f);
-    const float halfFovTan = fovTan * aspectRatio;
-    const float proj22 = hybridCst.proj[2][2];
-    const float proj32 = hybridCst.proj[3][2];
+    unsigned int runIdx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (runIdx >= numRuns) return;
 
-    __shared__ unsigned int s_workIdx;
-    __shared__ glm::vec4 shPa[SHARED_BATCH], shPb[SHARED_BATCH];
+    unsigned int tileId    = d_unique_out[runIdx];
+    unsigned int count     = d_counts_out[runIdx];
+    unsigned int runStart  = d_run_offsets[runIdx];
+    unsigned int numWG     = (count + SHARED_BATCH - 1) / SHARED_BATCH;
 
-    const unsigned int totalLightTiles = d_tileClassifyCounts[0];
+    unsigned int baseSlot = atomicAdd(d_wg_totalCount, numWG);
 
-    while (true) {
-        if (threadIdx.x == 0 && threadIdx.y == 0) {
-            s_workIdx = atomicAdd(&g_nextLightWorkItem, 1u);
-        }
-        __syncthreads();
+    for (unsigned int g = 0; g < numWG; g++) {
+        unsigned int wgStart = g * SHARED_BATCH;
+        unsigned int wgCount = min((unsigned int)SHARED_BATCH, count - wgStart);
+        d_wg_tileId    [baseSlot + g] = tileId;
+        d_wg_entityStart[baseSlot + g] = runStart + wgStart;
+        d_wg_entityCount[baseSlot + g] = wgCount;
+    }
+}
 
-        if (s_workIdx >= totalLightTiles) return;
+__device__ inline void writeFragmentSafe(
+    unsigned int* depthBuffer, int pixelIdx,
+    float depth, const glm::vec3& color,
+    cudaSurfaceObject_t outputImage, int px, int py)
+{
+    unsigned int newDepth = __float_as_uint(depth);
+    unsigned int old = depthBuffer[pixelIdx];
 
-        const unsigned int tileIdx = d_lightTileList[s_workIdx];
-        const unsigned int entityStart = d_tile_offsets[tileIdx];
-        const unsigned int entityEnd   = d_tile_offsets[tileIdx + 1];
-        const unsigned int entityCount = entityEnd - entityStart;
-
-        const unsigned int tileX = tileIdx % hybridCst.tilesX;
-        const unsigned int tileY = tileIdx / hybridCst.tilesX;
-        const int pixelX = tileX * TILE_SIZE + threadIdx.x;
-        const int pixelY = tileY * TILE_SIZE + threadIdx.y;
-        const bool validPixel = (pixelX < hybridCst.screenWidth && pixelY < hybridCst.screenHeight);
-
-        glm::vec3 rd, ray;
-        float minDepth = 1e30f;
-        if (validPixel) {
-            rd  = computeRayDirTiled(pixelX, pixelY, fovTan, halfFovTan);
-            ray = hybridCst.rayStart + (float)pixelX * hybridCst.dx + (float)pixelY * hybridCst.dy;
-            minDepth = __uint_as_float(depthBuffer[pixelY * hybridCst.screenWidth + pixelX]);
-        }
-        glm::vec3 finalColor(0.0f);
-        bool hasHit = false;
-
-        const unsigned int numBatches = (entityCount + SHARED_BATCH - 1) / SHARED_BATCH;
-        for (unsigned int batch = 0; batch < numBatches; batch++) {
-            unsigned int batchStart = batch * SHARED_BATCH;
-            unsigned int localIdx = threadIdx.y * TILE_SIZE + threadIdx.x;
-            if (localIdx < SHARED_BATCH) {
-                unsigned int entityIdx = batchStart + localIdx;
-                if (entityIdx < entityCount) {
-                    unsigned long long pair = d_tile_entity_pairs_sorted[entityStart + entityIdx];
-                    unsigned int cylIndex = (unsigned int)(pair & 0xFFFFFFFFu);
-                    Cylinder cyl = d_cylinders[cylIndex];
-                    shPa[localIdx] = cyl.pa_r;
-                    shPb[localIdx] = cyl.pb_r;
-                }
-            }
-            __syncthreads();
-
-            if (validPixel) {
-                unsigned int batchCount = min(SHARED_BATCH, entityCount - batchStart);
-                for (unsigned int i = 0; i < batchCount; i++) {
-                    glm::vec3 pa = glm::vec3(shPa[i]), pb = glm::vec3(shPb[i]);
-                    float ra = shPa[i].w;
-                    glm::vec4 tnor = iCylinderTiled(hybridCst.cameraPos, rd, pa, pb, ra);
-                    if (tnor.x > 0.0f) {
-                        float t = tnor.x;
-                        glm::vec3 hit = ray * t;
-                        float depth = __fdividef(fmaf(hit.z, proj22, proj32), -hit.z);
-                        if (depth < minDepth) {
-                            minDepth = depth;
-                            hasHit = true;
-                            glm::vec3 normal = glm::normalize(glm::vec3(tnor.y, tnor.z, tnor.w));
-                            float lambert = glm::max(0.0f, glm::dot(normal, -glm::normalize(rd * t)));
-                            finalColor = glm::vec3(bondsColor[0], bondsColor[1], bondsColor[2]) * lambert * diffuse;
-                        }
-                    }
-                }
-            }
-            __syncthreads();
-        }
-
-        if (validPixel && hasHit) {
-            int pixelIdx = pixelY * hybridCst.screenWidth + pixelX;
-            unsigned int depthU = __float_as_uint(minDepth);
-            depthBuffer[pixelIdx] = depthU;
+    while (__uint_as_float(old) > depth) {
+        unsigned int assumed = old;
+        old = atomicCAS(&depthBuffer[pixelIdx], assumed, newDepth);
+        if (old == assumed) {
             uchar4 pixel = make_uchar4(
-                (unsigned char)(finalColor.x * 255.0f),
-                (unsigned char)(finalColor.y * 255.0f),
-                (unsigned char)(finalColor.z * 255.0f), 255);
-            surf2Dwrite(pixel, outputImage, pixelX * sizeof(uchar4), pixelY);
+                (unsigned char)(color.x * 255.0f),
+                (unsigned char)(color.y * 255.0f),
+                (unsigned char)(color.z * 255.0f), 255);
+            surf2Dwrite(pixel, outputImage, px * sizeof(uchar4), py);
+            return;
         }
-        __syncthreads();
     }
 }
 
-/** Heavy cylinder kernel: persistent threads, 1 batch per work-steal. atomicMin depth. */
-__global__ void heavyCylinderRasterKernel(
-    const Cylinder* __restrict__ d_cylinders,
-    const unsigned int* __restrict__ d_tile_offsets,
+
+// ─────────── Sphere tiled raster (one block per work group) ───────────
+
+__global__ void tiledSphereRasterWGKernel(
+    const glm::vec4* __restrict__ d_spheres,
     const unsigned long long* __restrict__ d_tile_entity_pairs_sorted,
-    const unsigned int* __restrict__ d_heavyTileIndices,
-    const unsigned int* __restrict__ d_heavyBatchStarts,
-    const unsigned int* __restrict__ d_tileClassifyCounts,
+    const unsigned int* __restrict__ d_wg_tileId,
+    const unsigned int* __restrict__ d_wg_entityStart,
+    const unsigned int* __restrict__ d_wg_entityCount,
     unsigned int* __restrict__ depthBuffer,
     cudaSurfaceObject_t outputImage)
 {
@@ -467,197 +135,203 @@ __global__ void heavyCylinderRasterKernel(
     const float proj22 = hybridCst.proj[2][2];
     const float proj32 = hybridCst.proj[3][2];
 
-    __shared__ unsigned int s_workIdx;
-    __shared__ unsigned int s_tileIdx;
-    __shared__ unsigned int s_batchStart;
-    __shared__ unsigned int s_batchCount;
+    __shared__ glm::vec4 shPosR[SHARED_BATCH];
+
+    const unsigned int wgIdx       = blockIdx.x;
+    const unsigned int tileIdx     = d_wg_tileId[wgIdx];
+    const unsigned int entityStart = d_wg_entityStart[wgIdx];
+    const unsigned int entityCount = d_wg_entityCount[wgIdx];
+
+    const unsigned int tileX  = tileIdx % hybridCst.tilesX;
+    const unsigned int tileY  = tileIdx / hybridCst.tilesX;
+    const int pixelX = tileX * TILE_SIZE + threadIdx.x;
+    const int pixelY = tileY * TILE_SIZE + threadIdx.y;
+    const bool validPixel = (pixelX < hybridCst.screenWidth && pixelY < hybridCst.screenHeight);
+
+    bool hasHit = false;
+    glm::vec3 finalColor = glm::vec3(0.0f);
+    float finalDepth = __uint_as_float(depthBuffer[pixelY * hybridCst.screenWidth + pixelX]);
+
+    // Load entities into shared memory
+    const unsigned int localIdx = threadIdx.y * TILE_SIZE + threadIdx.x;
+    if (localIdx < SHARED_BATCH && localIdx < entityCount) {
+        unsigned long long pair = d_tile_entity_pairs_sorted[entityStart + localIdx];
+        unsigned int sphereIndex = (unsigned int)(pair & 0xFFFFFFFFu);
+        shPosR[localIdx] = d_spheres[sphereIndex];
+    }
+    __syncthreads();
+
+    // Ray-trace; atomicMin since multiple blocks may share a tile
+    if (!validPixel) return;
+
+    glm::vec3 rd  = computeRayDirTiled(pixelX, pixelY, fovTan, halfFovTan);
+    glm::vec3 ray = hybridCst.rayStart + (float)pixelX * hybridCst.dx + (float)pixelY * hybridCst.dy;
+    const int pixelIdx = pixelY * hybridCst.screenWidth + pixelX;
+
+    for (unsigned int i = 0; i < entityCount; i++) {
+        glm::vec4 posR = shPosR[i];
+        float t = iSphereTiled(hybridCst.cameraPos, rd, glm::vec3(posR), posR.w);
+        if (t > 0.0f) {
+            glm::vec3 hit = ray * t;
+            float depth = __fdividef(fmaf(hit.z, proj22, proj32), -hit.z);
+            
+            if (depth < finalDepth) {
+                hasHit = true;
+                glm::vec3 worldHit = hybridCst.cameraPos + rd * t;
+                glm::vec3 normal = glm::normalize(worldHit - glm::vec3(posR));
+                float lambert = fmaxf(0.0f, glm::dot(normal, -glm::normalize(rd * t)));
+                finalColor = glm::vec3(atomsColor[0], atomsColor[1], atomsColor[2]) * lambert * diffuse;
+                finalDepth = depth;
+            }
+        }
+    }
+
+    if (hasHit)
+    {
+            writeFragmentSafe(depthBuffer, pixelIdx, finalDepth, finalColor,
+                          outputImage, pixelX, pixelY);
+    }
+    
+}
+
+// ─────────── Cylinder tiled raster (one block per work group) ───────────
+
+__global__ void tiledCylinderRasterWGKernel(
+    const Cylinder* __restrict__ d_cylinders,
+    const unsigned long long* __restrict__ d_tile_entity_pairs_sorted,
+    const unsigned int* __restrict__ d_wg_tileId,
+    const unsigned int* __restrict__ d_wg_entityStart,
+    const unsigned int* __restrict__ d_wg_entityCount,
+    unsigned int* __restrict__ depthBuffer,
+    cudaSurfaceObject_t outputImage)
+{
+    const float aspectRatio = (float)hybridCst.screenWidth / (float)hybridCst.screenHeight;
+    const float fovRad = glm::radians(hybridCst.fov);
+    const float fovTan = tanf(fovRad * 0.5f);
+    const float halfFovTan = fovTan * aspectRatio;
+    const float proj22 = hybridCst.proj[2][2];
+    const float proj32 = hybridCst.proj[3][2];
+
+    
     __shared__ glm::vec4 shPa[SHARED_BATCH], shPb[SHARED_BATCH];
 
-    const unsigned int totalHeavyWorkItems = d_tileClassifyCounts[1];
+    const unsigned int wgIdx       = blockIdx.x;
+    const unsigned int tileIdx     = d_wg_tileId[wgIdx];
+    const unsigned int entityStart = d_wg_entityStart[wgIdx];
+    const unsigned int entityCount = d_wg_entityCount[wgIdx];
 
-    while (true) {
-        if (threadIdx.x == 0 && threadIdx.y == 0) {
-            s_workIdx = atomicAdd(&g_nextHeavyWorkItem, 1u);
-        }
-        __syncthreads();
+    const unsigned int tileX  = tileIdx % hybridCst.tilesX;
+    const unsigned int tileY  = tileIdx / hybridCst.tilesX;
+    const int pixelX = tileX * TILE_SIZE + threadIdx.x;
+    const int pixelY = tileY * TILE_SIZE + threadIdx.y;
+    const bool validPixel = (pixelX < hybridCst.screenWidth && pixelY < hybridCst.screenHeight);
+    
+    bool hasHit = false;
+    glm::vec3 finalColor = glm::vec3(0.0f);
+    float finalDepth = __uint_as_float(depthBuffer[pixelY * hybridCst.screenWidth + pixelX]); 
 
-        if (s_workIdx >= totalHeavyWorkItems) return;
+    // Load entities into shared memory
+    const unsigned int localIdx = threadIdx.y * TILE_SIZE + threadIdx.x;
+    if (localIdx < SHARED_BATCH && localIdx < entityCount) {
+        unsigned long long pair = d_tile_entity_pairs_sorted[entityStart + localIdx];
+        unsigned int cylIndex = (unsigned int)(pair & 0xFFFFFFFFu);
+        Cylinder cyl = d_cylinders[cylIndex];
+        shPa[localIdx] = cyl.pa_r;
+        shPb[localIdx] = cyl.pb_r;
+    }
+    __syncthreads();
 
-        if (threadIdx.x == 0 && threadIdx.y == 0) {
-            unsigned int tileIdx = d_heavyTileIndices[s_workIdx];
-            unsigned int bStart  = d_heavyBatchStarts[s_workIdx];
-            unsigned int entityCount = d_tile_offsets[tileIdx + 1] - d_tile_offsets[tileIdx];
-            s_tileIdx    = tileIdx;
-            s_batchStart = bStart;
-            s_batchCount = min((unsigned int)SHARED_BATCH, entityCount - min(bStart, entityCount));
-        }
-        __syncthreads();
+    // Ray-trace; atomicMin since multiple blocks may share a tile
+    if (!validPixel) return;
 
-        const unsigned int tileIdx    = s_tileIdx;
-        const unsigned int batchStart = s_batchStart;
-        const unsigned int batchCount = s_batchCount;
+    glm::vec3 rd  = computeRayDirTiled(pixelX, pixelY, fovTan, halfFovTan);
+    glm::vec3 ray = hybridCst.rayStart + (float)pixelX * hybridCst.dx + (float)pixelY * hybridCst.dy;
+    const int pixelIdx = pixelY * hybridCst.screenWidth + pixelX;
 
-        if (batchCount == 0) { __syncthreads(); continue; }
-
-        const unsigned int tileX = tileIdx % hybridCst.tilesX;
-        const unsigned int tileY = tileIdx / hybridCst.tilesX;
-        const int pixelX = tileX * TILE_SIZE + threadIdx.x;
-        const int pixelY = tileY * TILE_SIZE + threadIdx.y;
-        const bool validPixel = (pixelX < hybridCst.screenWidth && pixelY < hybridCst.screenHeight);
-
-        const unsigned int entityStart = d_tile_offsets[tileIdx];
-        const unsigned int entityCount = d_tile_offsets[tileIdx + 1] - entityStart;
-        const unsigned int localIdx = threadIdx.y * TILE_SIZE + threadIdx.x;
-        if (localIdx < SHARED_BATCH) {
-            unsigned int entityIdx = batchStart + localIdx;
-            if (entityIdx < entityCount) {
-                unsigned long long pair = d_tile_entity_pairs_sorted[entityStart + entityIdx];
-                unsigned int cylIndex = (unsigned int)(pair & 0xFFFFFFFFu);
-                Cylinder cyl = d_cylinders[cylIndex];
-                shPa[localIdx] = cyl.pa_r;
-                shPb[localIdx] = cyl.pb_r;
+    for (unsigned int i = 0; i < entityCount; i++) {
+        glm::vec3 pa = glm::vec3(shPa[i]), pb = glm::vec3(shPb[i]);
+        float ra = shPa[i].w;
+        glm::vec4 tnor = iCylinderTiled(hybridCst.cameraPos, rd, pa, pb, ra);
+        if (tnor.x > 0.0f) {
+            float t = tnor.x;
+            glm::vec3 hit = ray * t;
+            float depth = __fdividef(fmaf(hit.z, proj22, proj32), -hit.z);
+            
+            if (depth < finalDepth) {
+                hasHit = true;
+                glm::vec3 normal = glm::normalize(glm::vec3(tnor.y, tnor.z, tnor.w));
+                float lambert = glm::max(0.0f, glm::dot(normal, -glm::normalize(rd * t)));
+                finalColor = glm::vec3(bondsColor[0], bondsColor[1], bondsColor[2]) * lambert * diffuse;
+                finalDepth = depth;
             }
         }
-        __syncthreads();
-
-        if (validPixel) {
-            glm::vec3 rd  = computeRayDirTiled(pixelX, pixelY, fovTan, halfFovTan);
-            glm::vec3 ray = hybridCst.rayStart + (float)pixelX * hybridCst.dx + (float)pixelY * hybridCst.dy;
-            const int pixelIdx = pixelY * hybridCst.screenWidth + pixelX;
-
-            for (unsigned int i = 0; i < batchCount; i++) {
-                glm::vec3 pa = glm::vec3(shPa[i]), pb = glm::vec3(shPb[i]);
-                float ra = shPa[i].w;
-                glm::vec4 tnor = iCylinderTiled(hybridCst.cameraPos, rd, pa, pb, ra);
-                if (tnor.x > 0.0f) {
-                    float t = tnor.x;
-                    glm::vec3 hit = ray * t;
-                    float depth = __fdividef(fmaf(hit.z, proj22, proj32), -hit.z);
-                    unsigned int depthU = __float_as_uint(depth);
-                    unsigned int old = atomicMin(&depthBuffer[pixelIdx], depthU);
-                    if (depthU < old) {
-                        glm::vec3 normal = glm::normalize(glm::vec3(tnor.y, tnor.z, tnor.w));
-                        float lambert = glm::max(0.0f, glm::dot(normal, -glm::normalize(rd * t)));
-                        glm::vec3 color = glm::vec3(bondsColor[0], bondsColor[1], bondsColor[2]) * lambert * diffuse;
-                        uchar4 pixel = make_uchar4(
-                            (unsigned char)(color.x * 255.0f),
-                            (unsigned char)(color.y * 255.0f),
-                            (unsigned char)(color.z * 255.0f), 255);
-                        surf2Dwrite(pixel, outputImage, pixelX * sizeof(uchar4), pixelY);
-                    }
-                }
-            }
-        }
-        __syncthreads();
     }
+
+    if (hasHit)
+    { 
+        writeFragmentSafe(depthBuffer, pixelIdx, finalDepth, finalColor,
+                        outputImage, pixelX, pixelY);   
+    }
+    
 }
 
-// Helper: query SM count (cached)
-static int getNumSMs() {
-    static int numSMs = 0;
-    if (numSMs == 0) {
-        int device = 0;
-        cudaGetDevice(&device);
-        cudaDeviceGetAttribute(&numSMs, cudaDevAttrMultiProcessorCount, device);
-    }
-    return numSMs;
+// ─────────── Launch wrappers (extern "C") ───────────
+
+extern "C" void launchExpandWorkGroups(
+    const unsigned int* d_unique_out,
+    const unsigned int* d_counts_out,
+    const unsigned int* d_run_offsets,
+    unsigned int numRuns,
+    unsigned int* d_wg_tileId,
+    unsigned int* d_wg_entityStart,
+    unsigned int* d_wg_entityCount,
+    unsigned int* d_wg_totalCount,
+    cudaStream_t stream)
+{
+    if (numRuns == 0) return;
+    int threads = 256;
+    int blocks = (numRuns + threads - 1) / threads;
+    expandWorkGroupsKernel<<<blocks, threads, 0, stream>>>(
+        d_unique_out, d_counts_out, d_run_offsets, numRuns,
+        d_wg_tileId, d_wg_entityStart, d_wg_entityCount, d_wg_totalCount);
 }
 
-extern "C" void launchTiledSphereRasterBinning(
+extern "C" void launchTiledSphereRasterWG(
     const glm::vec4* d_spheres,
-    const unsigned int* d_tile_offsets,
     const unsigned long long* d_tile_entity_pairs_sorted,
+    const unsigned int* d_wg_tileId,
+    const unsigned int* d_wg_entityStart,
+    const unsigned int* d_wg_entityCount,
+    unsigned int totalWorkGroups,
     unsigned int* d_depthBuffer,
     cudaSurfaceObject_t outputImage,
-    unsigned int tilesX,
-    unsigned int tilesY,
-    unsigned int* d_lightTileList,
-    unsigned int* d_heavyTileIndices,
-    unsigned int* d_heavyBatchStarts,
-    unsigned int* d_tileClassifyCounts,
     cudaStream_t stream)
 {
-    unsigned int totalTiles = tilesX * tilesY;
-
-    // Classify tiles into light and heavy lists
-    cudaMemsetAsync(d_tileClassifyCounts, 0, 2 * sizeof(unsigned int), stream);
-    {
-        int threads = 256;
-        int blocks = (totalTiles + threads - 1) / threads;
-        classifyTilesKernel<<<blocks, threads, 0, stream>>>(
-            d_tile_offsets, d_lightTileList, d_heavyTileIndices,
-            d_heavyBatchStarts, d_tileClassifyCounts, totalTiles);
-    }
-
-    int numSMs = getNumSMs();
+    if (totalWorkGroups == 0) return;
     dim3 block(TILE_SIZE, TILE_SIZE);
-    dim3 grid(numSMs * 2, 1);
-
-    // Light tiles: persistent threads, 1 tile per work-steal (no atomicMin)
-    {
-        unsigned int zero = 0;
-        cudaMemcpyToSymbolAsync(g_nextLightWorkItem, &zero, sizeof(unsigned int), 0, cudaMemcpyHostToDevice, stream);
-        lightSphereRasterKernel<<<grid, block, 0, stream>>>(
-            d_spheres, d_tile_offsets, d_tile_entity_pairs_sorted,
-            d_lightTileList, d_tileClassifyCounts,
-            d_depthBuffer, outputImage);
-    }
-
-    // Heavy tiles: persistent threads, 1 batch per work-steal (atomicMin depth)
-    {
-        unsigned int zero = 0;
-        cudaMemcpyToSymbolAsync(g_nextHeavyWorkItem, &zero, sizeof(unsigned int), 0, cudaMemcpyHostToDevice, stream);
-        heavySphereRasterKernel<<<grid, block, 0, stream>>>(
-            d_spheres, d_tile_offsets, d_tile_entity_pairs_sorted,
-            d_heavyTileIndices, d_heavyBatchStarts, d_tileClassifyCounts,
-            d_depthBuffer, outputImage);
-    }
+    dim3 grid(totalWorkGroups, 1);
+    tiledSphereRasterWGKernel<<<grid, block, 0, stream>>>(
+        d_spheres, d_tile_entity_pairs_sorted,
+        d_wg_tileId, d_wg_entityStart, d_wg_entityCount,
+        d_depthBuffer, outputImage);
 }
 
-extern "C" void launchTiledCylinderRasterBinning(
+extern "C" void launchTiledCylinderRasterWG(
     const Cylinder* d_cylinders,
-    const unsigned int* d_tile_offsets,
     const unsigned long long* d_tile_entity_pairs_sorted,
+    const unsigned int* d_wg_tileId,
+    const unsigned int* d_wg_entityStart,
+    const unsigned int* d_wg_entityCount,
+    unsigned int totalWorkGroups,
     unsigned int* d_depthBuffer,
     cudaSurfaceObject_t outputImage,
-    unsigned int tilesX,
-    unsigned int tilesY,
-    unsigned int* d_lightTileList,
-    unsigned int* d_heavyTileIndices,
-    unsigned int* d_heavyBatchStarts,
-    unsigned int* d_tileClassifyCounts,
     cudaStream_t stream)
 {
-    unsigned int totalTiles = tilesX * tilesY;
-
-    cudaMemsetAsync(d_tileClassifyCounts, 0, 2 * sizeof(unsigned int), stream);
-    {
-        int threads = 256;
-        int blocks = (totalTiles + threads - 1) / threads;
-        classifyTilesKernel<<<blocks, threads, 0, stream>>>(
-            d_tile_offsets, d_lightTileList, d_heavyTileIndices,
-            d_heavyBatchStarts, d_tileClassifyCounts, totalTiles);
-    }
-
-    int numSMs = getNumSMs();
+    if (totalWorkGroups == 0) return;
     dim3 block(TILE_SIZE, TILE_SIZE);
-    dim3 grid(numSMs * 2, 1);
-
-    {
-        unsigned int zero = 0;
-        cudaMemcpyToSymbolAsync(g_nextLightWorkItem, &zero, sizeof(unsigned int), 0, cudaMemcpyHostToDevice, stream);
-        lightCylinderRasterKernel<<<grid, block, 0, stream>>>(
-            d_cylinders, d_tile_offsets, d_tile_entity_pairs_sorted,
-            d_lightTileList, d_tileClassifyCounts,
-            d_depthBuffer, outputImage);
-    }
-
-    {
-        unsigned int zero = 0;
-        cudaMemcpyToSymbolAsync(g_nextHeavyWorkItem, &zero, sizeof(unsigned int), 0, cudaMemcpyHostToDevice, stream);
-        heavyCylinderRasterKernel<<<grid, block, 0, stream>>>(
-            d_cylinders, d_tile_offsets, d_tile_entity_pairs_sorted,
-            d_heavyTileIndices, d_heavyBatchStarts, d_tileClassifyCounts,
-            d_depthBuffer, outputImage);
-    }
+    dim3 grid(totalWorkGroups, 1);
+    tiledCylinderRasterWGKernel<<<grid, block, 0, stream>>>(
+        d_cylinders, d_tile_entity_pairs_sorted,
+        d_wg_tileId, d_wg_entityStart, d_wg_entityCount,
+        d_depthBuffer, outputImage);
 }

--- a/kernels/hybrid_binning/tiled_raster_binning.cu
+++ b/kernels/hybrid_binning/tiled_raster_binning.cu
@@ -7,7 +7,6 @@
 #include <cuda_runtime.h>
 #include <device_launch_parameters.h>
 #include <glm/glm.hpp>
-
 #include "hybrid_binning_types.h"
 #include "geometry/cylinder/cylinder.h"
 
@@ -15,6 +14,14 @@ extern __constant__ HybridConstants hybridCst;
 
 #define TILE_SIZE 16
 #define SHARED_BATCH 64
+#define HEAVY_TILE_THRESHOLD 256
+
+/** Work-stealing counters for persistent-thread bin-split kernels.
+ *  g_nextLightWorkItem: index into the compact light-tile list.
+ *  g_nextHeavyWorkItem: index into the expanded heavy work-item list.
+ *  Must be reset to 0 before each kernel launch. */
+__device__ unsigned int g_nextLightWorkItem;
+__device__ unsigned int g_nextHeavyWorkItem;
 
 __device__ inline float iSphereTiled(const glm::vec3& ro, const glm::vec3& rd,
                                      const glm::vec3& center, float radius) {
@@ -76,87 +83,243 @@ __device__ inline void computeSphereBBoxTiled(const glm::vec4& spherePosR,
     bboxMaxY = __float2int_ru(fmaf(maxC.y, 0.5f, 0.5f) * hybridCst.screenHeight);
 }
 
-__global__ void tiledSphereRasterBinningKernel(
+/** Classify tiles into light (single-block) and heavy (multi-block) lists.
+ *  - Empty tiles: skipped.
+ *  - Light tiles (entityCount in (0, HEAVY_TILE_THRESHOLD]): 1 entry in d_lightTileList.
+ *  - Heavy tiles (entityCount > HEAVY_TILE_THRESHOLD): ceil(entityCount/SHARED_BATCH)
+ *    work-items in d_heavyTileIndices + d_heavyBatchStarts.
+ *  d_tileClassifyCounts[0] = total light tiles, [1] = total heavy work items. */
+__global__ void classifyTilesKernel(
+    const unsigned int* __restrict__ d_tile_offsets,
+    unsigned int* __restrict__ d_lightTileList,
+    unsigned int* __restrict__ d_heavyTileIndices,
+    unsigned int* __restrict__ d_heavyBatchStarts,
+    unsigned int* __restrict__ d_tileClassifyCounts,
+    unsigned int totalTiles)
+{
+    unsigned int tid = blockIdx.x * blockDim.x + threadIdx.x;
+    if (tid >= totalTiles) return;
+    unsigned int entityCount = d_tile_offsets[tid + 1] - d_tile_offsets[tid];
+    if (entityCount == 0) return;
+
+    if (entityCount <= HEAVY_TILE_THRESHOLD) {
+        unsigned int idx = atomicAdd(&d_tileClassifyCounts[0], 1u);
+        d_lightTileList[idx] = tid;
+    } else {
+        unsigned int numBatches = (entityCount + SHARED_BATCH - 1) / SHARED_BATCH;
+        unsigned int base = atomicAdd(&d_tileClassifyCounts[1], numBatches);
+        for (unsigned int b = 0; b < numBatches; b++) {
+            d_heavyTileIndices[base + b] = tid;
+            d_heavyBatchStarts[base + b] = b * SHARED_BATCH;
+        }
+    }
+}
+
+/** Light sphere kernel: persistent threads, 1 tile per work-steal.
+ *  Only ONE block ever processes a given tile, so no atomicMin needed. */
+__global__ void lightSphereRasterKernel(
     const glm::vec4* __restrict__ d_spheres,
     const unsigned int* __restrict__ d_tile_offsets,
     const unsigned long long* __restrict__ d_tile_entity_pairs_sorted,
+    const unsigned int* __restrict__ d_lightTileList,
+    const unsigned int* __restrict__ d_tileClassifyCounts,
     unsigned int* __restrict__ depthBuffer,
     cudaSurfaceObject_t outputImage)
 {
-    const unsigned int tileX = blockIdx.x;
-    const unsigned int tileY = blockIdx.y;
-    const unsigned int tileIdx = tileY * hybridCst.tilesX + tileX;
-    const int pixelX = tileX * TILE_SIZE + threadIdx.x;
-    const int pixelY = tileY * TILE_SIZE + threadIdx.y;
-    if (pixelX >= hybridCst.screenWidth || pixelY >= hybridCst.screenHeight) return;
+    const float aspectRatio = (float)hybridCst.screenWidth / (float)hybridCst.screenHeight;
+    const float fovRad = glm::radians(hybridCst.fov);
+    const float fovTan = tanf(fovRad * 0.5f);
+    const float halfFovTan = fovTan * aspectRatio;
+    const float proj22 = hybridCst.proj[2][2];
+    const float proj32 = hybridCst.proj[3][2];
 
-    const unsigned int entityStart = d_tile_offsets[tileIdx];
-    const unsigned int entityEnd = d_tile_offsets[tileIdx + 1];
-    const unsigned int entityCount = entityEnd - entityStart;
-    if (entityCount == 0) return;
-
+    __shared__ unsigned int s_workIdx;
     __shared__ glm::vec4 shPosR[SHARED_BATCH];
 
-    float aspectRatio = (float)hybridCst.screenWidth / (float)hybridCst.screenHeight;
-    float fovRad = glm::radians(hybridCst.fov);
-    float fovTan = tanf(fovRad * 0.5f);
-    float halfFovTan = fovTan * aspectRatio;
+    const unsigned int totalLightTiles = d_tileClassifyCounts[0];
 
-    glm::vec3 ray = hybridCst.rayStart + (float)pixelX * hybridCst.dx + (float)pixelY * hybridCst.dy;
+    while (true) {
+        if (threadIdx.x == 0 && threadIdx.y == 0) {
+            s_workIdx = atomicAdd(&g_nextLightWorkItem, 1u);
+        }
+        __syncthreads();
 
-    glm::vec3 rd = computeRayDirTiled(pixelX, pixelY, fovTan, halfFovTan);
-    float minDepth = __uint_as_float(depthBuffer[pixelY * hybridCst.screenWidth + pixelX]);
-    glm::vec3 finalColor(0.0f);
-    bool hasHit = false;
+        if (s_workIdx >= totalLightTiles) return;
 
-    unsigned int numBatches = (entityCount + SHARED_BATCH - 1) / SHARED_BATCH;
-    for (unsigned int batch = 0; batch < numBatches; batch++) {
-        unsigned int batchStart = batch * SHARED_BATCH;
-        unsigned int localIdx = threadIdx.y * TILE_SIZE + threadIdx.x;
+        const unsigned int tileIdx = d_lightTileList[s_workIdx];
+        const unsigned int entityStart = d_tile_offsets[tileIdx];
+        const unsigned int entityEnd   = d_tile_offsets[tileIdx + 1];
+        const unsigned int entityCount = entityEnd - entityStart;
+
+        const unsigned int tileX = tileIdx % hybridCst.tilesX;
+        const unsigned int tileY = tileIdx / hybridCst.tilesX;
+        const int pixelX = tileX * TILE_SIZE + threadIdx.x;
+        const int pixelY = tileY * TILE_SIZE + threadIdx.y;
+        const bool validPixel = (pixelX < hybridCst.screenWidth && pixelY < hybridCst.screenHeight);
+
+        glm::vec3 rd, ray;
+        float minDepth = 1e30f;
+        if (validPixel) {
+            rd  = computeRayDirTiled(pixelX, pixelY, fovTan, halfFovTan);
+            ray = hybridCst.rayStart + (float)pixelX * hybridCst.dx + (float)pixelY * hybridCst.dy;
+            minDepth = __uint_as_float(depthBuffer[pixelY * hybridCst.screenWidth + pixelX]);
+        }
+        glm::vec3 finalColor(0.0f);
+        bool hasHit = false;
+
+        // Process ALL batches for this light tile within this single block
+        const unsigned int numBatches = (entityCount + SHARED_BATCH - 1) / SHARED_BATCH;
+        for (unsigned int batch = 0; batch < numBatches; batch++) {
+            unsigned int batchStart = batch * SHARED_BATCH;
+            unsigned int localIdx = threadIdx.y * TILE_SIZE + threadIdx.x;
+            if (localIdx < SHARED_BATCH) {
+                unsigned int entityIdx = batchStart + localIdx;
+                if (entityIdx < entityCount) {
+                    unsigned long long pair = d_tile_entity_pairs_sorted[entityStart + entityIdx];
+                    unsigned int sphereIndex = (unsigned int)(pair & 0xFFFFFFFFu);
+                    shPosR[localIdx] = d_spheres[sphereIndex];
+                }
+            }
+            __syncthreads();
+
+            if (validPixel) {
+                unsigned int batchCount = min(SHARED_BATCH, entityCount - batchStart);
+                for (unsigned int i = 0; i < batchCount; i++) {
+                    glm::vec4 posR = shPosR[i];
+                    float t = iSphereTiled(hybridCst.cameraPos, rd, glm::vec3(posR), posR.w);
+                    if (t > 0.0f) {
+                        glm::vec3 hit = ray * t;
+                        float depth = __fdividef(fmaf(hit.z, proj22, proj32), -hit.z);
+                        if (depth < minDepth) {
+                            minDepth = depth;
+                            hasHit = true;
+                            glm::vec3 worldHit = hybridCst.cameraPos + rd * t;
+                            glm::vec3 normal = glm::normalize(worldHit - glm::vec3(posR));
+                            float lambert = fmaxf(0.0f, glm::dot(normal, -glm::normalize(rd * t)));
+                            finalColor = glm::vec3(atomsColor[0], atomsColor[1], atomsColor[2]) * lambert * diffuse;
+                        }
+                    }
+                }
+            }
+            __syncthreads();
+        }
+
+        // Single block owns this tile — direct write, no atomicMin
+        if (validPixel && hasHit) {
+            int pixelIdx = pixelY * hybridCst.screenWidth + pixelX;
+            unsigned int depthU = __float_as_uint(minDepth);
+            depthBuffer[pixelIdx] = depthU;
+            uchar4 pixel = make_uchar4(
+                (unsigned char)(finalColor.x * 255.0f),
+                (unsigned char)(finalColor.y * 255.0f),
+                (unsigned char)(finalColor.z * 255.0f), 255);
+            surf2Dwrite(pixel, outputImage, pixelX * sizeof(uchar4), pixelY);
+        }
+        __syncthreads();
+    }
+}
+
+/** Heavy sphere kernel: persistent threads, 1 batch per work-steal.
+ *  Multiple blocks may process the same tile -> atomicMin on depth buffer. */
+__global__ void heavySphereRasterKernel(
+    const glm::vec4* __restrict__ d_spheres,
+    const unsigned int* __restrict__ d_tile_offsets,
+    const unsigned long long* __restrict__ d_tile_entity_pairs_sorted,
+    const unsigned int* __restrict__ d_heavyTileIndices,
+    const unsigned int* __restrict__ d_heavyBatchStarts,
+    const unsigned int* __restrict__ d_tileClassifyCounts,
+    unsigned int* __restrict__ depthBuffer,
+    cudaSurfaceObject_t outputImage)
+{
+    const float aspectRatio = (float)hybridCst.screenWidth / (float)hybridCst.screenHeight;
+    const float fovRad = glm::radians(hybridCst.fov);
+    const float fovTan = tanf(fovRad * 0.5f);
+    const float halfFovTan = fovTan * aspectRatio;
+    const float proj22 = hybridCst.proj[2][2];
+    const float proj32 = hybridCst.proj[3][2];
+
+    __shared__ unsigned int s_workIdx;
+    __shared__ unsigned int s_tileIdx;
+    __shared__ unsigned int s_batchStart;
+    __shared__ unsigned int s_batchCount;
+    __shared__ glm::vec4 shPosR[SHARED_BATCH];
+
+    const unsigned int totalHeavyWorkItems = d_tileClassifyCounts[1];
+
+    while (true) {
+        if (threadIdx.x == 0 && threadIdx.y == 0) {
+            s_workIdx = atomicAdd(&g_nextHeavyWorkItem, 1u);
+        }
+        __syncthreads();
+
+        if (s_workIdx >= totalHeavyWorkItems) return;
+
+        // Decode which tile and which batch this work item represents
+        if (threadIdx.x == 0 && threadIdx.y == 0) {
+            unsigned int tileIdx = d_heavyTileIndices[s_workIdx];
+            unsigned int bStart  = d_heavyBatchStarts[s_workIdx];
+            unsigned int entityCount = d_tile_offsets[tileIdx + 1] - d_tile_offsets[tileIdx];
+            s_tileIdx    = tileIdx;
+            s_batchStart = bStart;
+            s_batchCount = min((unsigned int)SHARED_BATCH, entityCount - min(bStart, entityCount));
+        }
+        __syncthreads();
+
+        const unsigned int tileIdx    = s_tileIdx;
+        const unsigned int batchStart = s_batchStart;
+        const unsigned int batchCount = s_batchCount;
+
+        if (batchCount == 0) { __syncthreads(); continue; }
+
+        const unsigned int tileX = tileIdx % hybridCst.tilesX;
+        const unsigned int tileY = tileIdx / hybridCst.tilesX;
+        const int pixelX = tileX * TILE_SIZE + threadIdx.x;
+        const int pixelY = tileY * TILE_SIZE + threadIdx.y;
+        const bool validPixel = (pixelX < hybridCst.screenWidth && pixelY < hybridCst.screenHeight);
+
+        // Load one batch of entities into shared memory
+        const unsigned int entityStart = d_tile_offsets[tileIdx];
+        const unsigned int entityCount = d_tile_offsets[tileIdx + 1] - entityStart;
+        const unsigned int localIdx = threadIdx.y * TILE_SIZE + threadIdx.x;
         if (localIdx < SHARED_BATCH) {
             unsigned int entityIdx = batchStart + localIdx;
             if (entityIdx < entityCount) {
                 unsigned long long pair = d_tile_entity_pairs_sorted[entityStart + entityIdx];
                 unsigned int sphereIndex = (unsigned int)(pair & 0xFFFFFFFFu);
-                glm::vec4 posR = d_spheres[sphereIndex];
-                shPosR[localIdx] = posR;
+                shPosR[localIdx] = d_spheres[sphereIndex];
             }
         }
         __syncthreads();
 
-        unsigned int batchCount = min(SHARED_BATCH, entityCount - batchStart);
-        for (unsigned int i = 0; i < batchCount; i++) {
-            
-            glm::vec4 posR = shPosR[i];
-            float t = iSphereTiled(hybridCst.cameraPos, rd, glm::vec3(posR), posR.w);
-            if (t > 0.0f) {
-                glm::vec3 hit = ray * t;
-                float proj22 = hybridCst.proj[2][2];
-                float proj32 = hybridCst.proj[3][2];
-                float depth = __fdividef(fmaf(hit.z, proj22, proj32), -hit.z);
-                if (depth < minDepth) {
-                    minDepth = depth;
-                    hasHit = true;
-                    glm::vec3 worldHit = hybridCst.cameraPos + rd * t;
-                    glm::vec3 normal = glm::normalize(worldHit - glm::vec3(posR));
-                    float lambert = fmaxf(0.0f, glm::dot(normal, -glm::normalize(rd * t)));
-                    finalColor = glm::vec3(atomsColor[0], atomsColor[1], atomsColor[2]) * lambert * diffuse;
+        // Ray-trace this single batch; atomicMin for depth since multiple blocks share the tile
+        if (validPixel) {
+            glm::vec3 rd  = computeRayDirTiled(pixelX, pixelY, fovTan, halfFovTan);
+            glm::vec3 ray = hybridCst.rayStart + (float)pixelX * hybridCst.dx + (float)pixelY * hybridCst.dy;
+            const int pixelIdx = pixelY * hybridCst.screenWidth + pixelX;
+
+            for (unsigned int i = 0; i < batchCount; i++) {
+                glm::vec4 posR = shPosR[i];
+                float t = iSphereTiled(hybridCst.cameraPos, rd, glm::vec3(posR), posR.w);
+                if (t > 0.0f) {
+                    glm::vec3 hit = ray * t;
+                    float depth = __fdividef(fmaf(hit.z, proj22, proj32), -hit.z);
+                    unsigned int depthU = __float_as_uint(depth);
+                    unsigned int old = atomicMin(&depthBuffer[pixelIdx], depthU);
+                    if (depthU < old) {
+                        glm::vec3 worldHit = hybridCst.cameraPos + rd * t;
+                        glm::vec3 normal = glm::normalize(worldHit - glm::vec3(posR));
+                        float lambert = fmaxf(0.0f, glm::dot(normal, -glm::normalize(rd * t)));
+                        glm::vec3 color = glm::vec3(atomsColor[0], atomsColor[1], atomsColor[2]) * lambert * diffuse;
+                        uchar4 pixel = make_uchar4(
+                            (unsigned char)(color.x * 255.0f),
+                            (unsigned char)(color.y * 255.0f),
+                            (unsigned char)(color.z * 255.0f), 255);
+                        surf2Dwrite(pixel, outputImage, pixelX * sizeof(uchar4), pixelY);
+                    }
                 }
             }
         }
         __syncthreads();
-    }
-
-    if (hasHit) {
-        int pixelIdx = pixelY * hybridCst.screenWidth + pixelX;
-        unsigned int depthU = __float_as_uint(minDepth);
-        depthBuffer[pixelIdx] = depthU;
-        uchar4 pixel = make_uchar4(
-            (unsigned char)(finalColor.x * 255.0f),
-            (unsigned char)(finalColor.y * 255.0f),
-            (unsigned char)(finalColor.z * 255.0f), 255);
-        surf2Dwrite(pixel, outputImage, pixelX * sizeof(uchar4), pixelY);
-        
     }
 }
 
@@ -182,42 +345,169 @@ __device__ inline glm::vec4 iCylinderTiled(const glm::vec3& ro, const glm::vec3&
     return glm::vec4(-1.0f);
 }
 
-__global__ void tiledCylinderRasterBinningKernel(
+/** Light cylinder kernel: persistent threads, 1 tile per work-steal. No atomicMin. */
+__global__ void lightCylinderRasterKernel(
     const Cylinder* __restrict__ d_cylinders,
     const unsigned int* __restrict__ d_tile_offsets,
     const unsigned long long* __restrict__ d_tile_entity_pairs_sorted,
+    const unsigned int* __restrict__ d_lightTileList,
+    const unsigned int* __restrict__ d_tileClassifyCounts,
     unsigned int* __restrict__ depthBuffer,
     cudaSurfaceObject_t outputImage)
 {
-    const unsigned int tileX = blockIdx.x;
-    const unsigned int tileY = blockIdx.y;
-    const unsigned int tileIdx = tileY * hybridCst.tilesX + tileX;
-    const int pixelX = tileX * TILE_SIZE + threadIdx.x;
-    const int pixelY = tileY * TILE_SIZE + threadIdx.y;
-    if (pixelX >= hybridCst.screenWidth || pixelY >= hybridCst.screenHeight) return;
+    const float aspectRatio = (float)hybridCst.screenWidth / (float)hybridCst.screenHeight;
+    const float fovRad = glm::radians(hybridCst.fov);
+    const float fovTan = tanf(fovRad * 0.5f);
+    const float halfFovTan = fovTan * aspectRatio;
+    const float proj22 = hybridCst.proj[2][2];
+    const float proj32 = hybridCst.proj[3][2];
 
-    const unsigned int entityStart = d_tile_offsets[tileIdx];
-    const unsigned int entityEnd = d_tile_offsets[tileIdx + 1];
-    const unsigned int entityCount = entityEnd - entityStart;
-    if (entityCount == 0) return;
-
+    __shared__ unsigned int s_workIdx;
     __shared__ glm::vec4 shPa[SHARED_BATCH], shPb[SHARED_BATCH];
 
-    float aspectRatio = (float)hybridCst.screenWidth / (float)hybridCst.screenHeight;
-    float fovRad = glm::radians(hybridCst.fov);
-    float fovTan = tanf(fovRad * 0.5f);
-    float halfFovTan = fovTan * aspectRatio;
-    glm::vec3 rd = computeRayDirTiled(pixelX, pixelY, fovTan, halfFovTan);
-    float minDepth = __uint_as_float(depthBuffer[pixelY * hybridCst.screenWidth + pixelX]);
-    glm::vec3 finalColor(0.0f);
-    bool hasHit = false;
+    const unsigned int totalLightTiles = d_tileClassifyCounts[0];
 
-    glm::vec3 ray = hybridCst.rayStart + (float)pixelX * hybridCst.dx + (float)pixelY * hybridCst.dy;
+    while (true) {
+        if (threadIdx.x == 0 && threadIdx.y == 0) {
+            s_workIdx = atomicAdd(&g_nextLightWorkItem, 1u);
+        }
+        __syncthreads();
 
-    unsigned int numBatches = (entityCount + SHARED_BATCH - 1) / SHARED_BATCH;
-    for (unsigned int batch = 0; batch < numBatches; batch++) {
-        unsigned int batchStart = batch * SHARED_BATCH;
-        unsigned int localIdx = threadIdx.y * TILE_SIZE + threadIdx.x;
+        if (s_workIdx >= totalLightTiles) return;
+
+        const unsigned int tileIdx = d_lightTileList[s_workIdx];
+        const unsigned int entityStart = d_tile_offsets[tileIdx];
+        const unsigned int entityEnd   = d_tile_offsets[tileIdx + 1];
+        const unsigned int entityCount = entityEnd - entityStart;
+
+        const unsigned int tileX = tileIdx % hybridCst.tilesX;
+        const unsigned int tileY = tileIdx / hybridCst.tilesX;
+        const int pixelX = tileX * TILE_SIZE + threadIdx.x;
+        const int pixelY = tileY * TILE_SIZE + threadIdx.y;
+        const bool validPixel = (pixelX < hybridCst.screenWidth && pixelY < hybridCst.screenHeight);
+
+        glm::vec3 rd, ray;
+        float minDepth = 1e30f;
+        if (validPixel) {
+            rd  = computeRayDirTiled(pixelX, pixelY, fovTan, halfFovTan);
+            ray = hybridCst.rayStart + (float)pixelX * hybridCst.dx + (float)pixelY * hybridCst.dy;
+            minDepth = __uint_as_float(depthBuffer[pixelY * hybridCst.screenWidth + pixelX]);
+        }
+        glm::vec3 finalColor(0.0f);
+        bool hasHit = false;
+
+        const unsigned int numBatches = (entityCount + SHARED_BATCH - 1) / SHARED_BATCH;
+        for (unsigned int batch = 0; batch < numBatches; batch++) {
+            unsigned int batchStart = batch * SHARED_BATCH;
+            unsigned int localIdx = threadIdx.y * TILE_SIZE + threadIdx.x;
+            if (localIdx < SHARED_BATCH) {
+                unsigned int entityIdx = batchStart + localIdx;
+                if (entityIdx < entityCount) {
+                    unsigned long long pair = d_tile_entity_pairs_sorted[entityStart + entityIdx];
+                    unsigned int cylIndex = (unsigned int)(pair & 0xFFFFFFFFu);
+                    Cylinder cyl = d_cylinders[cylIndex];
+                    shPa[localIdx] = cyl.pa_r;
+                    shPb[localIdx] = cyl.pb_r;
+                }
+            }
+            __syncthreads();
+
+            if (validPixel) {
+                unsigned int batchCount = min(SHARED_BATCH, entityCount - batchStart);
+                for (unsigned int i = 0; i < batchCount; i++) {
+                    glm::vec3 pa = glm::vec3(shPa[i]), pb = glm::vec3(shPb[i]);
+                    float ra = shPa[i].w;
+                    glm::vec4 tnor = iCylinderTiled(hybridCst.cameraPos, rd, pa, pb, ra);
+                    if (tnor.x > 0.0f) {
+                        float t = tnor.x;
+                        glm::vec3 hit = ray * t;
+                        float depth = __fdividef(fmaf(hit.z, proj22, proj32), -hit.z);
+                        if (depth < minDepth) {
+                            minDepth = depth;
+                            hasHit = true;
+                            glm::vec3 normal = glm::normalize(glm::vec3(tnor.y, tnor.z, tnor.w));
+                            float lambert = glm::max(0.0f, glm::dot(normal, -glm::normalize(rd * t)));
+                            finalColor = glm::vec3(bondsColor[0], bondsColor[1], bondsColor[2]) * lambert * diffuse;
+                        }
+                    }
+                }
+            }
+            __syncthreads();
+        }
+
+        if (validPixel && hasHit) {
+            int pixelIdx = pixelY * hybridCst.screenWidth + pixelX;
+            unsigned int depthU = __float_as_uint(minDepth);
+            depthBuffer[pixelIdx] = depthU;
+            uchar4 pixel = make_uchar4(
+                (unsigned char)(finalColor.x * 255.0f),
+                (unsigned char)(finalColor.y * 255.0f),
+                (unsigned char)(finalColor.z * 255.0f), 255);
+            surf2Dwrite(pixel, outputImage, pixelX * sizeof(uchar4), pixelY);
+        }
+        __syncthreads();
+    }
+}
+
+/** Heavy cylinder kernel: persistent threads, 1 batch per work-steal. atomicMin depth. */
+__global__ void heavyCylinderRasterKernel(
+    const Cylinder* __restrict__ d_cylinders,
+    const unsigned int* __restrict__ d_tile_offsets,
+    const unsigned long long* __restrict__ d_tile_entity_pairs_sorted,
+    const unsigned int* __restrict__ d_heavyTileIndices,
+    const unsigned int* __restrict__ d_heavyBatchStarts,
+    const unsigned int* __restrict__ d_tileClassifyCounts,
+    unsigned int* __restrict__ depthBuffer,
+    cudaSurfaceObject_t outputImage)
+{
+    const float aspectRatio = (float)hybridCst.screenWidth / (float)hybridCst.screenHeight;
+    const float fovRad = glm::radians(hybridCst.fov);
+    const float fovTan = tanf(fovRad * 0.5f);
+    const float halfFovTan = fovTan * aspectRatio;
+    const float proj22 = hybridCst.proj[2][2];
+    const float proj32 = hybridCst.proj[3][2];
+
+    __shared__ unsigned int s_workIdx;
+    __shared__ unsigned int s_tileIdx;
+    __shared__ unsigned int s_batchStart;
+    __shared__ unsigned int s_batchCount;
+    __shared__ glm::vec4 shPa[SHARED_BATCH], shPb[SHARED_BATCH];
+
+    const unsigned int totalHeavyWorkItems = d_tileClassifyCounts[1];
+
+    while (true) {
+        if (threadIdx.x == 0 && threadIdx.y == 0) {
+            s_workIdx = atomicAdd(&g_nextHeavyWorkItem, 1u);
+        }
+        __syncthreads();
+
+        if (s_workIdx >= totalHeavyWorkItems) return;
+
+        if (threadIdx.x == 0 && threadIdx.y == 0) {
+            unsigned int tileIdx = d_heavyTileIndices[s_workIdx];
+            unsigned int bStart  = d_heavyBatchStarts[s_workIdx];
+            unsigned int entityCount = d_tile_offsets[tileIdx + 1] - d_tile_offsets[tileIdx];
+            s_tileIdx    = tileIdx;
+            s_batchStart = bStart;
+            s_batchCount = min((unsigned int)SHARED_BATCH, entityCount - min(bStart, entityCount));
+        }
+        __syncthreads();
+
+        const unsigned int tileIdx    = s_tileIdx;
+        const unsigned int batchStart = s_batchStart;
+        const unsigned int batchCount = s_batchCount;
+
+        if (batchCount == 0) { __syncthreads(); continue; }
+
+        const unsigned int tileX = tileIdx % hybridCst.tilesX;
+        const unsigned int tileY = tileIdx / hybridCst.tilesX;
+        const int pixelX = tileX * TILE_SIZE + threadIdx.x;
+        const int pixelY = tileY * TILE_SIZE + threadIdx.y;
+        const bool validPixel = (pixelX < hybridCst.screenWidth && pixelY < hybridCst.screenHeight);
+
+        const unsigned int entityStart = d_tile_offsets[tileIdx];
+        const unsigned int entityCount = d_tile_offsets[tileIdx + 1] - entityStart;
+        const unsigned int localIdx = threadIdx.y * TILE_SIZE + threadIdx.x;
         if (localIdx < SHARED_BATCH) {
             unsigned int entityIdx = batchStart + localIdx;
             if (entityIdx < entityCount) {
@@ -230,40 +520,47 @@ __global__ void tiledCylinderRasterBinningKernel(
         }
         __syncthreads();
 
-        unsigned int batchCount = min(SHARED_BATCH, entityCount - batchStart);
-        glm::vec2 pixelCenter((float)pixelX + 0.5f, (float)pixelY + 0.5f);
-        for (unsigned int i = 0; i < batchCount; i++) {
-            
-            glm::vec3 pa = glm::vec3(shPa[i]), pb = glm::vec3(shPb[i]);
-            float ra = shPa[i].w;
-            glm::vec4 tnor = iCylinderTiled(hybridCst.cameraPos, rd, pa, pb, ra);
-            if (tnor.x > 0.0f) {
-                float t = tnor.x;
-                glm::vec3 hit = ray * t;
-                float depth = __fdividef(fmaf(hit.z, hybridCst.proj[2][2], hybridCst.proj[3][2]), -hit.z);
+        if (validPixel) {
+            glm::vec3 rd  = computeRayDirTiled(pixelX, pixelY, fovTan, halfFovTan);
+            glm::vec3 ray = hybridCst.rayStart + (float)pixelX * hybridCst.dx + (float)pixelY * hybridCst.dy;
+            const int pixelIdx = pixelY * hybridCst.screenWidth + pixelX;
 
-                if (depth < minDepth) {
-                    minDepth = depth;
-                    hasHit = true;
-                    glm::vec3 normal = glm::normalize(glm::vec3(tnor.y, tnor.z, tnor.w));
-                    float lambert = glm::max(0.0f, glm::dot(normal, -glm::normalize(rd * t)));
-                    finalColor = glm::vec3(bondsColor[0], bondsColor[1], bondsColor[2]) * lambert * diffuse;
+            for (unsigned int i = 0; i < batchCount; i++) {
+                glm::vec3 pa = glm::vec3(shPa[i]), pb = glm::vec3(shPb[i]);
+                float ra = shPa[i].w;
+                glm::vec4 tnor = iCylinderTiled(hybridCst.cameraPos, rd, pa, pb, ra);
+                if (tnor.x > 0.0f) {
+                    float t = tnor.x;
+                    glm::vec3 hit = ray * t;
+                    float depth = __fdividef(fmaf(hit.z, proj22, proj32), -hit.z);
+                    unsigned int depthU = __float_as_uint(depth);
+                    unsigned int old = atomicMin(&depthBuffer[pixelIdx], depthU);
+                    if (depthU < old) {
+                        glm::vec3 normal = glm::normalize(glm::vec3(tnor.y, tnor.z, tnor.w));
+                        float lambert = glm::max(0.0f, glm::dot(normal, -glm::normalize(rd * t)));
+                        glm::vec3 color = glm::vec3(bondsColor[0], bondsColor[1], bondsColor[2]) * lambert * diffuse;
+                        uchar4 pixel = make_uchar4(
+                            (unsigned char)(color.x * 255.0f),
+                            (unsigned char)(color.y * 255.0f),
+                            (unsigned char)(color.z * 255.0f), 255);
+                        surf2Dwrite(pixel, outputImage, pixelX * sizeof(uchar4), pixelY);
+                    }
                 }
             }
         }
         __syncthreads();
     }
+}
 
-    if (hasHit) {
-        int pixelIdx = pixelY * hybridCst.screenWidth + pixelX;
-        unsigned int depthU = __float_as_uint(minDepth);
-        depthBuffer[pixelIdx] = depthU;
-        uchar4 pixel = make_uchar4(
-            (unsigned char)(finalColor.x * 255.0f),
-            (unsigned char)(finalColor.y * 255.0f),
-            (unsigned char)(finalColor.z * 255.0f), 255);
-        surf2Dwrite(pixel, outputImage, pixelX * sizeof(uchar4), pixelY);
+// Helper: query SM count (cached)
+static int getNumSMs() {
+    static int numSMs = 0;
+    if (numSMs == 0) {
+        int device = 0;
+        cudaGetDevice(&device);
+        cudaDeviceGetAttribute(&numSMs, cudaDevAttrMultiProcessorCount, device);
     }
+    return numSMs;
 }
 
 extern "C" void launchTiledSphereRasterBinning(
@@ -274,12 +571,47 @@ extern "C" void launchTiledSphereRasterBinning(
     cudaSurfaceObject_t outputImage,
     unsigned int tilesX,
     unsigned int tilesY,
+    unsigned int* d_lightTileList,
+    unsigned int* d_heavyTileIndices,
+    unsigned int* d_heavyBatchStarts,
+    unsigned int* d_tileClassifyCounts,
     cudaStream_t stream)
 {
+    unsigned int totalTiles = tilesX * tilesY;
+
+    // Classify tiles into light and heavy lists
+    cudaMemsetAsync(d_tileClassifyCounts, 0, 2 * sizeof(unsigned int), stream);
+    {
+        int threads = 256;
+        int blocks = (totalTiles + threads - 1) / threads;
+        classifyTilesKernel<<<blocks, threads, 0, stream>>>(
+            d_tile_offsets, d_lightTileList, d_heavyTileIndices,
+            d_heavyBatchStarts, d_tileClassifyCounts, totalTiles);
+    }
+
+    int numSMs = getNumSMs();
     dim3 block(TILE_SIZE, TILE_SIZE);
-    dim3 grid(tilesX, tilesY);
-    tiledSphereRasterBinningKernel<<<grid, block, 0, stream>>>(
-        d_spheres, d_tile_offsets, d_tile_entity_pairs_sorted, d_depthBuffer, outputImage);
+    dim3 grid(numSMs * 2, 1);
+
+    // Light tiles: persistent threads, 1 tile per work-steal (no atomicMin)
+    {
+        unsigned int zero = 0;
+        cudaMemcpyToSymbolAsync(g_nextLightWorkItem, &zero, sizeof(unsigned int), 0, cudaMemcpyHostToDevice, stream);
+        lightSphereRasterKernel<<<grid, block, 0, stream>>>(
+            d_spheres, d_tile_offsets, d_tile_entity_pairs_sorted,
+            d_lightTileList, d_tileClassifyCounts,
+            d_depthBuffer, outputImage);
+    }
+
+    // Heavy tiles: persistent threads, 1 batch per work-steal (atomicMin depth)
+    {
+        unsigned int zero = 0;
+        cudaMemcpyToSymbolAsync(g_nextHeavyWorkItem, &zero, sizeof(unsigned int), 0, cudaMemcpyHostToDevice, stream);
+        heavySphereRasterKernel<<<grid, block, 0, stream>>>(
+            d_spheres, d_tile_offsets, d_tile_entity_pairs_sorted,
+            d_heavyTileIndices, d_heavyBatchStarts, d_tileClassifyCounts,
+            d_depthBuffer, outputImage);
+    }
 }
 
 extern "C" void launchTiledCylinderRasterBinning(
@@ -290,10 +622,42 @@ extern "C" void launchTiledCylinderRasterBinning(
     cudaSurfaceObject_t outputImage,
     unsigned int tilesX,
     unsigned int tilesY,
+    unsigned int* d_lightTileList,
+    unsigned int* d_heavyTileIndices,
+    unsigned int* d_heavyBatchStarts,
+    unsigned int* d_tileClassifyCounts,
     cudaStream_t stream)
 {
+    unsigned int totalTiles = tilesX * tilesY;
+
+    cudaMemsetAsync(d_tileClassifyCounts, 0, 2 * sizeof(unsigned int), stream);
+    {
+        int threads = 256;
+        int blocks = (totalTiles + threads - 1) / threads;
+        classifyTilesKernel<<<blocks, threads, 0, stream>>>(
+            d_tile_offsets, d_lightTileList, d_heavyTileIndices,
+            d_heavyBatchStarts, d_tileClassifyCounts, totalTiles);
+    }
+
+    int numSMs = getNumSMs();
     dim3 block(TILE_SIZE, TILE_SIZE);
-    dim3 grid(tilesX, tilesY);
-    tiledCylinderRasterBinningKernel<<<grid, block, 0, stream>>>(
-        d_cylinders, d_tile_offsets, d_tile_entity_pairs_sorted, d_depthBuffer, outputImage);
+    dim3 grid(numSMs * 2, 1);
+
+    {
+        unsigned int zero = 0;
+        cudaMemcpyToSymbolAsync(g_nextLightWorkItem, &zero, sizeof(unsigned int), 0, cudaMemcpyHostToDevice, stream);
+        lightCylinderRasterKernel<<<grid, block, 0, stream>>>(
+            d_cylinders, d_tile_offsets, d_tile_entity_pairs_sorted,
+            d_lightTileList, d_tileClassifyCounts,
+            d_depthBuffer, outputImage);
+    }
+
+    {
+        unsigned int zero = 0;
+        cudaMemcpyToSymbolAsync(g_nextHeavyWorkItem, &zero, sizeof(unsigned int), 0, cudaMemcpyHostToDevice, stream);
+        heavyCylinderRasterKernel<<<grid, block, 0, stream>>>(
+            d_cylinders, d_tile_offsets, d_tile_entity_pairs_sorted,
+            d_heavyTileIndices, d_heavyBatchStarts, d_tileClassifyCounts,
+            d_depthBuffer, outputImage);
+    }
 }

--- a/kernels/hybrid_binning/tiled_raster_binning.cu
+++ b/kernels/hybrid_binning/tiled_raster_binning.cu
@@ -29,11 +29,8 @@ __device__ inline float iSphereTiled(const glm::vec3& ro, const glm::vec3& rd,
     return -b - sqrtf(h);
 }
 
-__device__ inline glm::vec3 computeRayDirTiled(int px, int py, float fovTan, float halfFovTan) {
-    glm::vec2 p = (-glm::vec2(hybridCst.screenWidth, hybridCst.screenHeight) +
-                   2.0f * glm::vec2(px, py)) / glm::vec2(hybridCst.screenWidth, hybridCst.screenHeight);
-    return glm::normalize(p.x * hybridCst.right * halfFovTan +
-                          p.y * hybridCst.up * fovTan + hybridCst.front);
+__device__ inline glm::vec3 fastNormalize(const glm::vec3& v) {
+    return v * rsqrtf(glm::dot(v, v));
 }
 
 __device__ inline glm::vec4 iCylinderTiled(const glm::vec3& ro, const glm::vec3& rd,
@@ -100,7 +97,7 @@ __device__ inline void writeFragmentSafe(
     cudaSurfaceObject_t outputImage, int px, int py)
 {
     unsigned int newDepth = __float_as_uint(depth);
-    unsigned int old = depthBuffer[pixelIdx];
+    unsigned int old = __ldg(&depthBuffer[pixelIdx]);
 
     while (__uint_as_float(old) > depth) {
         unsigned int assumed = old;
@@ -128,19 +125,15 @@ __global__ void tiledSphereRasterWGKernel(
     unsigned int* __restrict__ depthBuffer,
     cudaSurfaceObject_t outputImage)
 {
-    const float aspectRatio = (float)hybridCst.screenWidth / (float)hybridCst.screenHeight;
-    const float fovRad = glm::radians(hybridCst.fov);
-    const float fovTan = tanf(fovRad * 0.5f);
-    const float halfFovTan = fovTan * aspectRatio;
     const float proj22 = hybridCst.proj[2][2];
     const float proj32 = hybridCst.proj[3][2];
 
     __shared__ glm::vec4 shPosR[SHARED_BATCH];
 
     const unsigned int wgIdx       = blockIdx.x;
-    const unsigned int tileIdx     = d_wg_tileId[wgIdx];
-    const unsigned int entityStart = d_wg_entityStart[wgIdx];
-    const unsigned int entityCount = d_wg_entityCount[wgIdx];
+    const unsigned int tileIdx     = __ldg(&d_wg_tileId[wgIdx]);
+    const unsigned int entityStart = __ldg(&d_wg_entityStart[wgIdx]);
+    const unsigned int entityCount = __ldg(&d_wg_entityCount[wgIdx]);
 
     const unsigned int tileX  = tileIdx % hybridCst.tilesX;
     const unsigned int tileY  = tileIdx / hybridCst.tilesX;
@@ -150,7 +143,7 @@ __global__ void tiledSphereRasterWGKernel(
 
     bool hasHit = false;
     glm::vec3 finalColor = glm::vec3(0.0f);
-    float finalDepth = __uint_as_float(depthBuffer[pixelY * hybridCst.screenWidth + pixelX]);
+    float finalDepth = __uint_as_float(__ldg(&depthBuffer[pixelY * hybridCst.screenWidth + pixelX]));
 
     // Load entities into shared memory
     const unsigned int localIdx = threadIdx.y * TILE_SIZE + threadIdx.x;
@@ -164,8 +157,8 @@ __global__ void tiledSphereRasterWGKernel(
     // Ray-trace; atomicMin since multiple blocks may share a tile
     if (!validPixel) return;
 
-    glm::vec3 rd  = computeRayDirTiled(pixelX, pixelY, fovTan, halfFovTan);
     glm::vec3 ray = hybridCst.rayStart + (float)pixelX * hybridCst.dx + (float)pixelY * hybridCst.dy;
+    glm::vec3 rd  = fastNormalize(ray.x * hybridCst.right + ray.y * hybridCst.up - ray.z * hybridCst.front);
     const int pixelIdx = pixelY * hybridCst.screenWidth + pixelX;
 
     for (unsigned int i = 0; i < entityCount; i++) {
@@ -177,9 +170,8 @@ __global__ void tiledSphereRasterWGKernel(
             
             if (depth < finalDepth) {
                 hasHit = true;
-                glm::vec3 worldHit = hybridCst.cameraPos + rd * t;
-                glm::vec3 normal = glm::normalize(worldHit - glm::vec3(posR));
-                float lambert = fmaxf(0.0f, glm::dot(normal, -glm::normalize(rd * t)));
+                glm::vec3 normal = fastNormalize(hybridCst.cameraPos + rd * t - glm::vec3(posR));
+                float lambert = fmaxf(0.0f, glm::dot(normal, -rd));
                 finalColor = glm::vec3(atomsColor[0], atomsColor[1], atomsColor[2]) * lambert * diffuse;
                 finalDepth = depth;
             }
@@ -205,20 +197,15 @@ __global__ void tiledCylinderRasterWGKernel(
     unsigned int* __restrict__ depthBuffer,
     cudaSurfaceObject_t outputImage)
 {
-    const float aspectRatio = (float)hybridCst.screenWidth / (float)hybridCst.screenHeight;
-    const float fovRad = glm::radians(hybridCst.fov);
-    const float fovTan = tanf(fovRad * 0.5f);
-    const float halfFovTan = fovTan * aspectRatio;
     const float proj22 = hybridCst.proj[2][2];
     const float proj32 = hybridCst.proj[3][2];
 
-    
     __shared__ glm::vec4 shPa[SHARED_BATCH], shPb[SHARED_BATCH];
 
     const unsigned int wgIdx       = blockIdx.x;
-    const unsigned int tileIdx     = d_wg_tileId[wgIdx];
-    const unsigned int entityStart = d_wg_entityStart[wgIdx];
-    const unsigned int entityCount = d_wg_entityCount[wgIdx];
+    const unsigned int tileIdx     = __ldg(&d_wg_tileId[wgIdx]);
+    const unsigned int entityStart = __ldg(&d_wg_entityStart[wgIdx]);
+    const unsigned int entityCount = __ldg(&d_wg_entityCount[wgIdx]);
 
     const unsigned int tileX  = tileIdx % hybridCst.tilesX;
     const unsigned int tileY  = tileIdx / hybridCst.tilesX;
@@ -228,7 +215,7 @@ __global__ void tiledCylinderRasterWGKernel(
     
     bool hasHit = false;
     glm::vec3 finalColor = glm::vec3(0.0f);
-    float finalDepth = __uint_as_float(depthBuffer[pixelY * hybridCst.screenWidth + pixelX]); 
+    float finalDepth = __uint_as_float(__ldg(&depthBuffer[pixelY * hybridCst.screenWidth + pixelX])); 
 
     // Load entities into shared memory
     const unsigned int localIdx = threadIdx.y * TILE_SIZE + threadIdx.x;
@@ -244,8 +231,8 @@ __global__ void tiledCylinderRasterWGKernel(
     // Ray-trace; atomicMin since multiple blocks may share a tile
     if (!validPixel) return;
 
-    glm::vec3 rd  = computeRayDirTiled(pixelX, pixelY, fovTan, halfFovTan);
     glm::vec3 ray = hybridCst.rayStart + (float)pixelX * hybridCst.dx + (float)pixelY * hybridCst.dy;
+    glm::vec3 rd  = fastNormalize(ray.x * hybridCst.right + ray.y * hybridCst.up - ray.z * hybridCst.front);
     const int pixelIdx = pixelY * hybridCst.screenWidth + pixelX;
 
     for (unsigned int i = 0; i < entityCount; i++) {
@@ -259,8 +246,8 @@ __global__ void tiledCylinderRasterWGKernel(
             
             if (depth < finalDepth) {
                 hasHit = true;
-                glm::vec3 normal = glm::normalize(glm::vec3(tnor.y, tnor.z, tnor.w));
-                float lambert = glm::max(0.0f, glm::dot(normal, -glm::normalize(rd * t)));
+                glm::vec3 normal = fastNormalize(glm::vec3(tnor.y, tnor.z, tnor.w));
+                float lambert = fmaxf(0.0f, glm::dot(normal, -rd));
                 finalColor = glm::vec3(bondsColor[0], bondsColor[1], bondsColor[2]) * lambert * diffuse;
                 finalDepth = depth;
             }

--- a/kernels/hybrid_binning/tiled_raster_binning.cu
+++ b/kernels/hybrid_binning/tiled_raster_binning.cu
@@ -96,8 +96,6 @@ __global__ void tiledSphereRasterBinningKernel(
     if (entityCount == 0) return;
 
     __shared__ glm::vec4 shPosR[SHARED_BATCH];
-    __shared__ int shBboxMinX[SHARED_BATCH], shBboxMinY[SHARED_BATCH];
-    __shared__ int shBboxMaxX[SHARED_BATCH], shBboxMaxY[SHARED_BATCH];
 
     float aspectRatio = (float)hybridCst.screenWidth / (float)hybridCst.screenHeight;
     float fovRad = glm::radians(hybridCst.fov);
@@ -122,18 +120,13 @@ __global__ void tiledSphereRasterBinningKernel(
                 unsigned int sphereIndex = (unsigned int)(pair & 0xFFFFFFFFu);
                 glm::vec4 posR = d_spheres[sphereIndex];
                 shPosR[localIdx] = posR;
-                int bx0, by0, bx1, by1;
-                computeSphereBBoxTiled(posR, bx0, by0, bx1, by1);
-                shBboxMinX[localIdx] = bx0; shBboxMinY[localIdx] = by0;
-                shBboxMaxX[localIdx] = bx1; shBboxMaxY[localIdx] = by1;
             }
         }
         __syncthreads();
 
         unsigned int batchCount = min(SHARED_BATCH, entityCount - batchStart);
         for (unsigned int i = 0; i < batchCount; i++) {
-            if (pixelX < shBboxMinX[i] || pixelX >= shBboxMaxX[i] ||
-                pixelY < shBboxMinY[i] || pixelY >= shBboxMaxY[i]) continue;
+            
             glm::vec4 posR = shPosR[i];
             float t = iSphereTiled(hybridCst.cameraPos, rd, glm::vec3(posR), posR.w);
             if (t > 0.0f) {
@@ -168,23 +161,6 @@ __global__ void tiledSphereRasterBinningKernel(
 }
 
 
-// Cross product of 2D vectors
-__device__ inline float cross2D(glm::vec2 a, glm::vec2 b) 
-{
-    return a.x * b.y - a.y * b.x;
-}
-
-// Check if point is inside convex quadrilateral
-__device__ inline bool pointInQuad(glm::vec2 p, glm::vec2 q0, glm::vec2 q1, glm::vec2 q2, glm::vec2 q3) 
-{
-    float c0 = cross2D(q1 - q0, p - q0);
-    float c1 = cross2D(q2 - q1, p - q1);
-    float c2 = cross2D(q3 - q2, p - q2);
-    float c3 = cross2D(q0 - q3, p - q3);
-    
-    return (c0 >= 0 && c1 >= 0 && c2 >= 0 && c3 >= 0) ||
-           (c0 <= 0 && c1 <= 0 && c2 <= 0 && c3 <= 0);
-}
 
 // Cylinder: ray-cylinder and bbox from quad (simplified - reuse logic from hybrid tiled)
 __device__ inline glm::vec4 iCylinderTiled(const glm::vec3& ro, const glm::vec3& rd,
@@ -251,62 +227,6 @@ __global__ void tiledCylinderRasterBinningKernel(
                 Cylinder cyl = d_cylinders[cylIndex];
                 shPa[localIdx] = cyl.pa_r;
                 shPb[localIdx] = cyl.pb_r;
-
-                glm::vec3 pa = glm::vec3(cyl.pa_r), pb = glm::vec3(cyl.pb_r);
-                float radius = cyl.pa_r.w;
-                glm::vec4 camA = hybridCst.view * glm::vec4(pa, 1.0f);
-                glm::vec4 camB = hybridCst.view * glm::vec4(pb, 1.0f);
-                glm::vec3 camImpPosA, camImpPosB;
-                if ( camA.z < camB.z )
-                {
-                    camImpPosA = glm::vec3(camB);
-                    camImpPosB = glm::vec3(camA);
-                }
-                else
-                {
-                    camImpPosA = glm::vec3(camA);
-                    camImpPosB = glm::vec3(camB);
-                }
-                glm::vec3 center = glm::normalize( ( camImpPosA + camImpPosB ) * 0.5f );
-                // Cylinder axis
-                const glm::vec3 z = glm::normalize(camImpPosB - camImpPosA);
-
-                // Find orthonormal x,y axes orthogonal to cylinder axis
-                glm::vec3 x = glm::normalize(glm::cross(center, z));
-                glm::vec3 y = glm::normalize(glm::cross(x, z)); // make full basis
-
-                // Compute impostor construction vectors.
-                const float dV0 = glm::length( camImpPosA );
-                const float dV1 = glm::length( camImpPosB );
-
-                const float sinAngle = __fdividef(radius, dV0);
-                float		angle	 = asinf( sinAngle );
-                const glm::vec3	y1		 = y * radius;
-                const glm::vec3	x2		 = x * radius * cosf( angle );
-                const glm::vec3	y2		 = y1 * sinAngle;
-                angle				 = asinf( __fdividef(radius, dV1) );
-                const glm::vec3 x3		 = x * ( dV1 - radius ) * __tanf( angle );
-
-                // Compute impostors vertices.
-                const glm::vec3 v1 = camImpPosA - x2 + y2;
-                const glm::vec3 v2 = camImpPosA + x2 + y2;
-                const glm::vec3 v3 = camImpPosB - x3 + y1;
-                const glm::vec3 v4 = camImpPosB + x3 + y1;
-
-                const glm::vec4 v1Proj = hybridCst.proj * glm::vec4(v1, 1.0f);
-                const glm::vec4 v2Proj = hybridCst.proj * glm::vec4(v2, 1.0f);
-                const glm::vec4 v3Proj = hybridCst.proj * glm::vec4(v3, 1.0f);
-                const glm::vec4 v4Proj = hybridCst.proj * glm::vec4(v4, 1.0f);
-
-                glm::vec3 ndcv1Proj = glm::vec3(__fdividef(v1Proj.x, v1Proj.w), __fdividef(v1Proj.y, v1Proj.w), __fdividef(v1Proj.z, v1Proj.w));
-                glm::vec3 ndcv2Proj = glm::vec3(__fdividef(v2Proj.x, v2Proj.w), __fdividef(v2Proj.y, v2Proj.w), __fdividef(v2Proj.z, v2Proj.w));
-                glm::vec3 ndcv3Proj = glm::vec3(__fdividef(v3Proj.x, v3Proj.w), __fdividef(v3Proj.y, v3Proj.w), __fdividef(v3Proj.z, v3Proj.w));
-                glm::vec3 ndcv4Proj = glm::vec3(__fdividef(v4Proj.x, v4Proj.w), __fdividef(v4Proj.y, v4Proj.w), __fdividef(v4Proj.z, v4Proj.w));
-
-                shQuad[localIdx * 4 + 0] = glm::vec2(ndcv1Proj);
-                shQuad[localIdx * 4 + 1] = glm::vec2(ndcv2Proj);
-                shQuad[localIdx * 4 + 2] = glm::vec2(ndcv4Proj);
-                shQuad[localIdx * 4 + 3] = glm::vec2(ndcv3Proj);
             }
         }
         __syncthreads();
@@ -314,10 +234,7 @@ __global__ void tiledCylinderRasterBinningKernel(
         unsigned int batchCount = min(SHARED_BATCH, entityCount - batchStart);
         glm::vec2 pixelCenter((float)pixelX + 0.5f, (float)pixelY + 0.5f);
         for (unsigned int i = 0; i < batchCount; i++) {
-            glm::vec2 q0 = shQuad[i * 4 + 0], q1 = shQuad[i * 4 + 1];
-            glm::vec2 q2 = shQuad[i * 4 + 2], q3 = shQuad[i * 4 + 3];
             
-            if (!pointInQuad(pixelCenter, q0, q1, q2, q3)) continue;
             glm::vec3 pa = glm::vec3(shPa[i]), pb = glm::vec3(shPb[i]);
             float ra = shPa[i].w;
             glm::vec4 tnor = iCylinderTiled(hybridCst.cameraPos, rd, pa, pb, ra);

--- a/kernels/hybrid_binning/tiled_raster_binning.cu
+++ b/kernels/hybrid_binning/tiled_raster_binning.cu
@@ -104,8 +104,10 @@ __global__ void tiledSphereRasterBinningKernel(
     float fovTan = tanf(fovRad * 0.5f);
     float halfFovTan = fovTan * aspectRatio;
 
+    glm::vec3 ray = hybridCst.rayStart + (float)pixelX * hybridCst.dx + (float)pixelY * hybridCst.dy;
+
     glm::vec3 rd = computeRayDirTiled(pixelX, pixelY, fovTan, halfFovTan);
-    float minDepth = depthBuffer[pixelY * hybridCst.screenWidth + pixelX];
+    float minDepth = __uint_as_float(depthBuffer[pixelY * hybridCst.screenWidth + pixelX]);
     glm::vec3 finalColor(0.0f);
     bool hasHit = false;
 
@@ -135,14 +137,15 @@ __global__ void tiledSphereRasterBinningKernel(
             glm::vec4 posR = shPosR[i];
             float t = iSphereTiled(hybridCst.cameraPos, rd, glm::vec3(posR), posR.w);
             if (t > 0.0f) {
-                glm::vec3 hit = hybridCst.cameraPos + rd * t;
+                glm::vec3 hit = ray * t;
                 float proj22 = hybridCst.proj[2][2];
                 float proj32 = hybridCst.proj[3][2];
                 float depth = __fdividef(fmaf(hit.z, proj22, proj32), -hit.z);
                 if (depth < minDepth) {
                     minDepth = depth;
                     hasHit = true;
-                    glm::vec3 normal = glm::normalize(hit - glm::vec3(posR));
+                    glm::vec3 worldHit = hybridCst.cameraPos + rd * t;
+                    glm::vec3 normal = glm::normalize(worldHit - glm::vec3(posR));
                     float lambert = fmaxf(0.0f, glm::dot(normal, -glm::normalize(rd * t)));
                     finalColor = glm::vec3(atomsColor[0], atomsColor[1], atomsColor[2]) * lambert * diffuse;
                 }
@@ -230,9 +233,11 @@ __global__ void tiledCylinderRasterBinningKernel(
     float fovTan = tanf(fovRad * 0.5f);
     float halfFovTan = fovTan * aspectRatio;
     glm::vec3 rd = computeRayDirTiled(pixelX, pixelY, fovTan, halfFovTan);
-    float minDepth = depthBuffer[pixelY * hybridCst.screenWidth + pixelX];
+    float minDepth = __uint_as_float(depthBuffer[pixelY * hybridCst.screenWidth + pixelX]);
     glm::vec3 finalColor(0.0f);
     bool hasHit = false;
+
+    glm::vec3 ray = hybridCst.rayStart + (float)pixelX * hybridCst.dx + (float)pixelY * hybridCst.dy;
 
     unsigned int numBatches = (entityCount + SHARED_BATCH - 1) / SHARED_BATCH;
     for (unsigned int batch = 0; batch < numBatches; batch++) {
@@ -318,7 +323,7 @@ __global__ void tiledCylinderRasterBinningKernel(
             glm::vec4 tnor = iCylinderTiled(hybridCst.cameraPos, rd, pa, pb, ra);
             if (tnor.x > 0.0f) {
                 float t = tnor.x;
-                glm::vec3 hit = hybridCst.cameraPos + rd * t;
+                glm::vec3 hit = ray * t;
                 float depth = __fdividef(fmaf(hit.z, hybridCst.proj[2][2], hybridCst.proj[3][2]), -hit.z);
 
                 if (depth < minDepth) {

--- a/kernels/hybrid_binning/tiled_raster_binning.cu
+++ b/kernels/hybrid_binning/tiled_raster_binning.cu
@@ -1,0 +1,318 @@
+/**
+ * @file tiled_raster_binning.cu
+ * @brief Tiled rasterization using tileOffsets + sorted entity indices (no billboards).
+ * Loads sphere/cylinder data from original buffers; recomputes bbox in shared memory.
+ */
+
+#include <cuda_runtime.h>
+#include <device_launch_parameters.h>
+#include <glm/glm.hpp>
+
+#include "hybrid_binning_types.h"
+#include "geometry/cylinder/cylinder.h"
+
+extern __constant__ HybridConstants hybridCst;
+
+#define TILE_SIZE 16
+#define SHARED_BATCH 64
+
+__device__ inline float iSphereTiled(const glm::vec3& ro, const glm::vec3& rd,
+                                     const glm::vec3& center, float radius) {
+    glm::vec3 oc = ro - center;
+    float b = glm::dot(oc, rd);
+    float c = glm::dot(oc, oc) - radius * radius;
+    float h = b * b - c;
+    if (h < 0.0f) return -1.0f;
+    return -b - sqrtf(h);
+}
+
+__device__ inline glm::vec3 computeRayDirTiled(int px, int py, float fovTan, float halfFovTan) {
+    glm::vec2 p = (-glm::vec2(hybridCst.screenWidth, hybridCst.screenHeight) +
+                   2.0f * glm::vec2(px, py)) / glm::vec2(hybridCst.screenWidth, hybridCst.screenHeight);
+    return glm::normalize(p.x * hybridCst.right * halfFovTan +
+                          p.y * hybridCst.up * fovTan + hybridCst.front);
+}
+
+__device__ inline void computeSphereBBoxTiled(const glm::vec4& spherePosR,
+    int& bboxMinX, int& bboxMinY, int& bboxMaxX, int& bboxMaxY) {
+    glm::vec4 camSpace4 = hybridCst.view * glm::vec4(glm::vec3(spherePosR), 1.0f);
+    glm::vec3 cameraSpaceSphere = glm::vec3(camSpace4);
+    glm::vec3 normCamSpaceSphere = glm::normalize(cameraSpaceSphere);
+    glm::vec3 camImposPos = cameraSpaceSphere - normCamSpaceSphere * spherePosR.w;
+    float dist = glm::length(cameraSpaceSphere) + 1e-6f;
+    float sinAngle = spherePosR.w / dist;
+    float tanAngle = tanf(asinf(fminf(sinAngle, 0.999f)));
+    float quadScale = tanAngle * glm::length(camImposPos);
+    glm::vec3 upVec(0.0f, 1.0f, 0.0f);
+    glm::vec3 impU = glm::normalize(glm::cross(normCamSpaceSphere, upVec));
+    if (glm::length(impU) < 0.001f) impU = glm::vec3(1.0f, 0.0f, 0.0f);
+    glm::vec3 impV = glm::cross(impU, normCamSpaceSphere) * quadScale;
+    impU *= quadScale;
+    glm::vec3 corners[4] = {
+        camImposPos + impU + impV, camImposPos - impU + impV,
+        camImposPos + impU - impV, camImposPos - impU - impV
+    };
+    float minCx = 1e6f, minCy = 1e6f, maxCx = -1e6f, maxCy = -1e6f;
+    for (int i = 0; i < 4; i++) {
+        glm::vec4 clip = hybridCst.proj * glm::vec4(corners[i], 1.0f);
+        float iw = 1.0f / clip.w;
+        float x = clip.x * iw, y = clip.y * iw;
+        minCx = fminf(minCx, x); minCy = fminf(minCy, y);
+        maxCx = fmaxf(maxCx, x); maxCy = fmaxf(maxCy, y);
+    }
+    bboxMinX = (int)floorf((minCx * 0.5f + 0.5f) * hybridCst.screenWidth);
+    bboxMinY = (int)floorf((minCy * 0.5f + 0.5f) * hybridCst.screenHeight);
+    bboxMaxX = (int)ceilf((maxCx * 0.5f + 0.5f) * hybridCst.screenWidth);
+    bboxMaxY = (int)ceilf((maxCy * 0.5f + 0.5f) * hybridCst.screenHeight);
+    bboxMinX = max(0, bboxMinX); bboxMinY = max(0, bboxMinY);
+    bboxMaxX = min(hybridCst.screenWidth, bboxMaxX);
+    bboxMaxY = min(hybridCst.screenHeight, bboxMaxY);
+}
+
+__global__ void tiledSphereRasterBinningKernel(
+    const glm::vec4* __restrict__ d_spheres,
+    const unsigned int* __restrict__ d_tile_offsets,
+    const unsigned int* __restrict__ d_sorted_entity_indices,
+    unsigned int* __restrict__ depthBuffer,
+    cudaSurfaceObject_t outputImage)
+{
+    const unsigned int tileX = blockIdx.x;
+    const unsigned int tileY = blockIdx.y;
+    const unsigned int tileIdx = tileY * hybridCst.tilesX + tileX;
+    const int pixelX = tileX * TILE_SIZE + threadIdx.x;
+    const int pixelY = tileY * TILE_SIZE + threadIdx.y;
+    if (pixelX >= hybridCst.screenWidth || pixelY >= hybridCst.screenHeight) return;
+
+    const unsigned int entityStart = d_tile_offsets[tileIdx];
+    const unsigned int entityEnd = d_tile_offsets[tileIdx + 1];
+    const unsigned int entityCount = entityEnd - entityStart;
+    if (entityCount == 0) return;
+
+    __shared__ glm::vec4 shPosR[SHARED_BATCH];
+    __shared__ int shBboxMinX[SHARED_BATCH], shBboxMinY[SHARED_BATCH];
+    __shared__ int shBboxMaxX[SHARED_BATCH], shBboxMaxY[SHARED_BATCH];
+
+    float aspectRatio = (float)hybridCst.screenWidth / (float)hybridCst.screenHeight;
+    float fovRad = glm::radians(hybridCst.fov);
+    float fovTan = tanf(fovRad * 0.5f);
+    float halfFovTan = fovTan * aspectRatio;
+    glm::vec3 rd = computeRayDirTiled(pixelX, pixelY, fovTan, halfFovTan);
+    float minDepth = 1e10f;
+    glm::vec3 finalColor(0.0f);
+    bool hasHit = false;
+
+    unsigned int numBatches = (entityCount + SHARED_BATCH - 1) / SHARED_BATCH;
+    for (unsigned int batch = 0; batch < numBatches; batch++) {
+        unsigned int batchStart = batch * SHARED_BATCH;
+        unsigned int localIdx = threadIdx.y * TILE_SIZE + threadIdx.x;
+        if (localIdx < SHARED_BATCH) {
+            unsigned int entityIdx = batchStart + localIdx;
+            if (entityIdx < entityCount) {
+                unsigned int sphereIndex = d_sorted_entity_indices[entityStart + entityIdx];
+                glm::vec4 posR = d_spheres[sphereIndex];
+                shPosR[localIdx] = posR;
+                int bx0, by0, bx1, by1;
+                computeSphereBBoxTiled(posR, bx0, by0, bx1, by1);
+                shBboxMinX[localIdx] = bx0; shBboxMinY[localIdx] = by0;
+                shBboxMaxX[localIdx] = bx1; shBboxMaxY[localIdx] = by1;
+            }
+        }
+        __syncthreads();
+
+        unsigned int batchCount = min(SHARED_BATCH, entityCount - batchStart);
+        for (unsigned int i = 0; i < batchCount; i++) {
+            if (pixelX < shBboxMinX[i] || pixelX >= shBboxMaxX[i] ||
+                pixelY < shBboxMinY[i] || pixelY >= shBboxMaxY[i]) continue;
+            glm::vec4 posR = shPosR[i];
+            float t = iSphereTiled(hybridCst.cameraPos, rd, glm::vec3(posR), posR.w);
+            if (t > 0.0f) {
+                glm::vec3 hit = hybridCst.cameraPos + rd * t;
+                glm::vec4 hitClip = hybridCst.proj * (hybridCst.view * glm::vec4(hit, 1.0f));
+                float depth = hitClip.z / hitClip.w;
+                if (depth < minDepth) {
+                    minDepth = depth;
+                    hasHit = true;
+                    glm::vec3 normal = glm::normalize(hit - glm::vec3(posR));
+                    float lambert = fmaxf(0.0f, glm::dot(normal, -glm::normalize(rd)));
+                    finalColor = glm::vec3(0.01f, 1.0f, 0.05f) * lambert * 0.9f;
+                }
+            }
+        }
+        __syncthreads();
+    }
+
+    if (hasHit) {
+        int pixelIdx = pixelY * hybridCst.screenWidth + pixelX;
+        unsigned int depthU = __float_as_uint(minDepth);
+        unsigned int old = atomicMin(&depthBuffer[pixelIdx], depthU);
+        if (__uint_as_float(old) > minDepth) {
+            uchar4 pixel = make_uchar4(
+                (unsigned char)(finalColor.x * 255.0f),
+                (unsigned char)(finalColor.y * 255.0f),
+                (unsigned char)(finalColor.z * 255.0f), 255);
+            surf2Dwrite(pixel, outputImage, pixelX * sizeof(uchar4), pixelY);
+        }
+    }
+}
+
+// Cylinder: ray-cylinder and bbox from quad (simplified - reuse logic from hybrid tiled)
+__device__ inline glm::vec4 iCylinderTiled(const glm::vec3& ro, const glm::vec3& rd,
+    const glm::vec3& pa, const glm::vec3& pb, float ra) {
+    glm::vec3 ba = pb - pa, oc = ro - pa;
+    float baba = glm::dot(ba, ba), bard = glm::dot(ba, rd), baoc = glm::dot(ba, oc);
+    float k2 = baba - bard * bard;
+    float k1 = baba * glm::dot(oc, rd) - baoc * bard;
+    float k0 = baba * glm::dot(oc, oc) - baoc * baoc - ra * ra * baba;
+    float h = k1 * k1 - k2 * k0;
+    if (h < 0.0f) return glm::vec4(-1.0f);
+    h = sqrtf(h);
+    float t = (-k1 - h) / k2;
+    float y = baoc + t * bard;
+    if (y > 0.0f && y < baba) return glm::vec4(t, oc + t * rd - ba * y / baba);
+    return glm::vec4(-1.0f);
+}
+
+__global__ void tiledCylinderRasterBinningKernel(
+    const Cylinder* __restrict__ d_cylinders,
+    const unsigned int* __restrict__ d_tile_offsets,
+    const unsigned int* __restrict__ d_sorted_entity_indices,
+    unsigned int* __restrict__ depthBuffer,
+    cudaSurfaceObject_t outputImage)
+{
+    const unsigned int tileX = blockIdx.x;
+    const unsigned int tileY = blockIdx.y;
+    const unsigned int tileIdx = tileY * hybridCst.tilesX + tileX;
+    const int pixelX = tileX * TILE_SIZE + threadIdx.x;
+    const int pixelY = tileY * TILE_SIZE + threadIdx.y;
+    if (pixelX >= hybridCst.screenWidth || pixelY >= hybridCst.screenHeight) return;
+
+    const unsigned int entityStart = d_tile_offsets[tileIdx];
+    const unsigned int entityEnd = d_tile_offsets[tileIdx + 1];
+    const unsigned int entityCount = entityEnd - entityStart;
+    if (entityCount == 0) return;
+
+    __shared__ glm::vec4 shPa[SHARED_BATCH], shPb[SHARED_BATCH];
+    __shared__ glm::vec2 shQuad[SHARED_BATCH * 4];
+
+    float aspectRatio = (float)hybridCst.screenWidth / (float)hybridCst.screenHeight;
+    float fovRad = glm::radians(hybridCst.fov);
+    float fovTan = tanf(fovRad * 0.5f);
+    float halfFovTan = fovTan * aspectRatio;
+    glm::vec3 rd = computeRayDirTiled(pixelX, pixelY, fovTan, halfFovTan);
+    float minDepth = 1e10f;
+    glm::vec3 finalColor(0.0f);
+    bool hasHit = false;
+
+    unsigned int numBatches = (entityCount + SHARED_BATCH - 1) / SHARED_BATCH;
+    for (unsigned int batch = 0; batch < numBatches; batch++) {
+        unsigned int batchStart = batch * SHARED_BATCH;
+        unsigned int localIdx = threadIdx.y * TILE_SIZE + threadIdx.x;
+        if (localIdx < SHARED_BATCH) {
+            unsigned int entityIdx = batchStart + localIdx;
+            if (entityIdx < entityCount) {
+                unsigned int cylIndex = d_sorted_entity_indices[entityStart + entityIdx];
+                Cylinder cyl = d_cylinders[cylIndex];
+                shPa[localIdx] = cyl.pa_r;
+                shPb[localIdx] = cyl.pb_r;
+                glm::vec3 pa = glm::vec3(cyl.pa_r), pb = glm::vec3(cyl.pb_r);
+                float radius = cyl.pa_r.w;
+                glm::vec4 camA = hybridCst.view * glm::vec4(pa, 1.0f);
+                glm::vec4 camB = hybridCst.view * glm::vec4(pb, 1.0f);
+                glm::vec3 camImpPosA = glm::vec3(camA), camImpPosB = glm::vec3(camB);
+                if (camImpPosA.z > camImpPosB.z) { glm::vec3 tmp = camImpPosA; camImpPosA = camImpPosB; camImpPosB = tmp; }
+                glm::vec3 z = glm::normalize(camImpPosB - camImpPosA);
+                glm::vec3 center = glm::normalize((camImpPosA + camImpPosB) * 0.5f);
+                glm::vec3 x = glm::normalize(glm::cross(center, z));
+                glm::vec3 y = glm::normalize(glm::cross(x, z));
+                float dV0 = glm::length(camImpPosA), dV1 = glm::length(camImpPosB);
+                float sinA0 = radius / dV0, sinA1 = radius / dV1;
+                float angle0 = asinf(fminf(sinA0, 0.999f)), angle1 = asinf(fminf(sinA1, 0.999f));
+                glm::vec3 v1 = camImpPosA - x * (radius * cosf(angle0)) + y * (radius * sinA0);
+                glm::vec3 v2 = camImpPosA + x * (radius * cosf(angle0)) + y * (radius * sinA0);
+                glm::vec3 v3 = camImpPosB - x * (float)(dV1 - radius) * tanf(angle1) + y * radius;
+                glm::vec3 v4 = camImpPosB + x * (float)(dV1 - radius) * tanf(angle1) + y * radius;
+                for (int k = 0; k < 4; k++) {
+                    glm::vec3 v = (k == 0) ? v1 : (k == 1) ? v2 : (k == 2) ? v4 : v3;
+                    glm::vec4 clip = hybridCst.proj * glm::vec4(v, 1.0f);
+                    glm::vec2 ndc = glm::vec2(clip.x / clip.w, clip.y / clip.w);
+                    shQuad[localIdx * 4 + k] = (ndc * 0.5f + 0.5f) * glm::vec2(hybridCst.screenWidth, hybridCst.screenHeight);
+                }
+            }
+        }
+        __syncthreads();
+
+        unsigned int batchCount = min(SHARED_BATCH, entityCount - batchStart);
+        glm::vec2 pixelCenter((float)pixelX + 0.5f, (float)pixelY + 0.5f);
+        for (unsigned int i = 0; i < batchCount; i++) {
+            glm::vec2 q0 = shQuad[i * 4 + 0], q1 = shQuad[i * 4 + 1];
+            glm::vec2 q2 = shQuad[i * 4 + 2], q3 = shQuad[i * 4 + 3];
+            float c0 = (q1.x - q0.x) * (pixelCenter.y - q0.y) - (q1.y - q0.y) * (pixelCenter.x - q0.x);
+            float c1 = (q2.x - q1.x) * (pixelCenter.y - q1.y) - (q2.y - q1.y) * (pixelCenter.x - q1.x);
+            float c2 = (q3.x - q2.x) * (pixelCenter.y - q2.y) - (q3.y - q2.y) * (pixelCenter.x - q2.x);
+            float c3 = (q0.x - q3.x) * (pixelCenter.y - q3.y) - (q0.y - q3.y) * (pixelCenter.x - q3.x);
+            bool inside = (c0 >= 0 && c1 >= 0 && c2 >= 0 && c3 >= 0) || (c0 <= 0 && c1 <= 0 && c2 <= 0 && c3 <= 0);
+            if (!inside) continue;
+            glm::vec3 pa = glm::vec3(shPa[i]), pb = glm::vec3(shPb[i]);
+            float ra = shPa[i].w;
+            glm::vec4 tnor = iCylinderTiled(hybridCst.cameraPos, rd, pa, pb, ra);
+            if (tnor.x > 0.0f) {
+                glm::vec3 hit = hybridCst.cameraPos + rd * tnor.x;
+                glm::vec4 hitClip = hybridCst.proj * (hybridCst.view * glm::vec4(hit, 1.0f));
+                float depth = hitClip.z / hitClip.w;
+                if (depth < minDepth) {
+                    minDepth = depth;
+                    hasHit = true;
+                    glm::vec3 normal = glm::normalize(tnor.yzw);
+                    float lambert = fmaxf(0.0f, glm::dot(normal, -glm::normalize(rd)));
+                    finalColor = glm::vec3(0.01f, 1.0f, 0.05f) * lambert * 0.9f;
+                }
+            }
+        }
+        __syncthreads();
+    }
+
+    if (hasHit) {
+        int pixelIdx = pixelY * hybridCst.screenWidth + pixelX;
+        unsigned int depthU = __float_as_uint(minDepth);
+        unsigned int old = atomicMin(&depthBuffer[pixelIdx], depthU);
+        if (__uint_as_float(old) > minDepth) {
+            uchar4 pixel = make_uchar4(
+                (unsigned char)(finalColor.x * 255.0f),
+                (unsigned char)(finalColor.y * 255.0f),
+                (unsigned char)(finalColor.z * 255.0f), 255);
+            surf2Dwrite(pixel, outputImage, pixelX * sizeof(uchar4), pixelY);
+        }
+    }
+}
+
+extern "C" void launchTiledSphereRasterBinning(
+    const glm::vec4* d_spheres,
+    const unsigned int* d_tile_offsets,
+    const unsigned int* d_sorted_entity_indices,
+    unsigned int* d_depthBuffer,
+    cudaSurfaceObject_t outputImage,
+    unsigned int tilesX,
+    unsigned int tilesY,
+    cudaStream_t stream)
+{
+    dim3 block(TILE_SIZE, TILE_SIZE);
+    dim3 grid(tilesX, tilesY);
+    tiledSphereRasterBinningKernel<<<grid, block, 0, stream>>>(
+        d_spheres, d_tile_offsets, d_sorted_entity_indices, d_depthBuffer, outputImage);
+}
+
+extern "C" void launchTiledCylinderRasterBinning(
+    const Cylinder* d_cylinders,
+    const unsigned int* d_tile_offsets,
+    const unsigned int* d_sorted_entity_indices,
+    unsigned int* d_depthBuffer,
+    cudaSurfaceObject_t outputImage,
+    unsigned int tilesX,
+    unsigned int tilesY,
+    cudaStream_t stream)
+{
+    dim3 block(TILE_SIZE, TILE_SIZE);
+    dim3 grid(tilesX, tilesY);
+    tiledCylinderRasterBinningKernel<<<grid, block, 0, stream>>>(
+        d_cylinders, d_tile_offsets, d_sorted_entity_indices, d_depthBuffer, outputImage);
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a sizeable new CUDA rendering path with complex GPU synchronization/atomic behavior and additional build targets; main risk is correctness/performance regressions in the new binning/sort/RLE and tiled raster kernels.
> 
> **Overview**
> Adds a new `cuda_hybrid_binning` executable and CUDA kernel set implementing a hybrid sphere/cylinder renderer that bins large entities *by sorting* `(tile_id, entity_id)` pairs (CUB radix sort + run-length encode) instead of per-tile linked lists.
> 
> The new pipeline performs frustum+BBox classification, emits tile/entity pairs for large entities, expands RLE runs into per-tile work-group dispatches, and rasterizes both small (per-entity) and large (tiled shared-memory batch) entities using atomic depth-buffer updates. Build tooling is updated to include the new target (`executables/CMakeLists.txt`) and add a `vs-release` CMake preset; legacy GLSL compute shader variants are checked in under `assets/shaders/hybrid_glsl/*_old.compute`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a7942a1fe2f2e068fc2409c4f3b8152f1c578021. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->