### PR TITLE
Hybrid cuda version persistent threads

### DIFF
--- a/executables/cuda_hybrid_binning/hybrid_binning_pipeline.cpp
+++ b/executables/cuda_hybrid_binning/hybrid_binning_pipeline.cpp
@@ -288,6 +288,7 @@ int main(int argc, char* argv[]) {
         profiler.updateProfiler(benchmark.getCheckpointID(), visibleSpheres, drawnSpheres, visibleCylinders, drawnCylinders);
 
         Frustum frustum(camera);
+        pipeline.setSmallEntityThreshold(config.smallEntityThreshold);
         pipeline.executeFrame(d_spheres, d_cylinders, depthBuffer, outputSurface, camera, frustum, stream);
         cudaStreamSynchronize(stream);  // ensure all kernels and D2H copies finish before reading stats
 

--- a/kernels/hybrid_binning/cylinder_pipeline_binning.cu
+++ b/kernels/hybrid_binning/cylinder_pipeline_binning.cu
@@ -39,26 +39,29 @@ extern "C" void sortPairs64AndBuildTileOffsets(
     size_t temp_scan_bytes,
     cudaStream_t stream);
 extern "C" void getRleTempStorageBytesForPairs64(size_t* out_bytes, int maxPairs);
-extern "C" void buildTileOffsetsFromRLE(
-    const unsigned int* d_unique_out, const unsigned int* d_counts_out,
-    unsigned int num_runs, unsigned int num_pairs, unsigned int total_tiles,
-    unsigned int* d_run_offsets, unsigned int* d_tile_offsets,
-    void* d_temp_scan, size_t temp_scan_bytes, cudaStream_t stream);
-extern "C" void launchScatterAndFillTileOffsets(
-    const unsigned int* d_unique_out, const unsigned int* d_run_offsets,
-    unsigned int num_runs, unsigned int num_pairs, unsigned int total_tiles,
-    unsigned int* d_tile_offsets, cudaStream_t stream);
 extern "C" void launchSmallCylinderRaster(
     const Cylinder* d_cylinders, const unsigned int* d_smallCylinderIndices,
     unsigned int smallCylinderCount, unsigned int* d_depthBuffer,
     cudaSurfaceObject_t outputImage, cudaStream_t stream);
-extern "C" void launchTiledCylinderRasterBinning(
-    const Cylinder* d_cylinders, const unsigned int* d_tile_offsets,
+extern "C" void launchExpandWorkGroups(
+    const unsigned int* d_unique_out,
+    const unsigned int* d_counts_out,
+    const unsigned int* d_run_offsets,
+    unsigned int numRuns,
+    unsigned int* d_wg_tileId,
+    unsigned int* d_wg_entityStart,
+    unsigned int* d_wg_entityCount,
+    unsigned int* d_wg_totalCount,
+    cudaStream_t stream);
+extern "C" void launchTiledCylinderRasterWG(
+    const Cylinder* d_cylinders,
     const unsigned long long* d_tile_entity_pairs_sorted,
-    unsigned int* d_depthBuffer, cudaSurfaceObject_t outputImage,
-    unsigned int tilesX, unsigned int tilesY,
-    unsigned int* d_lightTileList, unsigned int* d_heavyTileIndices,
-    unsigned int* d_heavyBatchStarts, unsigned int* d_tileClassifyCounts,
+    const unsigned int* d_wg_tileId,
+    const unsigned int* d_wg_entityStart,
+    const unsigned int* d_wg_entityCount,
+    unsigned int totalWorkGroups,
+    unsigned int* d_depthBuffer,
+    cudaSurfaceObject_t outputImage,
     cudaStream_t stream);
 
 #define CUDA_CHECK(call) do { cudaError_t e = call; if (e != cudaSuccess) printf("CUDA error %d: %s\n", e, cudaGetErrorString(e)); } while(0)
@@ -103,7 +106,14 @@ void initCylinderBinningResources(CylinderBinningResources* r, int maxCylinders,
     if (r->temp_sort64_bytes > 0) CUDA_CHECK(cudaMalloc(&r->d_temp_sort64, r->temp_sort64_bytes));
     if (r->temp_rle_bytes > 0) CUDA_CHECK(cudaMalloc(&r->d_temp_rle, r->temp_rle_bytes));
     if (r->temp_scan_bytes > 0) CUDA_CHECK(cudaMalloc(&r->d_temp_scan, r->temp_scan_bytes));
-    CUDA_CHECK(cudaMalloc(&r->d_tileClassifyCounts, 2 * sizeof(unsigned int)));
+
+    // Work-group expansion buffers
+    r->maxWorkGroups = r->maxPairs / SHARED_BATCH_SIZE + totalTiles;
+    CUDA_CHECK(cudaMalloc(&r->d_wg_tileId, r->maxWorkGroups * sizeof(unsigned int)));
+    CUDA_CHECK(cudaMalloc(&r->d_wg_entityStart, r->maxWorkGroups * sizeof(unsigned int)));
+    CUDA_CHECK(cudaMalloc(&r->d_wg_entityCount, r->maxWorkGroups * sizeof(unsigned int)));
+    CUDA_CHECK(cudaMalloc(&r->d_wg_totalCount, sizeof(unsigned int)));
+    CUDA_CHECK(cudaHostAlloc(&r->h_wg_totalCount, sizeof(unsigned int), cudaHostAllocDefault));
 }
 
 void freeCylinderBinningResources(CylinderBinningResources* r) {
@@ -125,7 +135,11 @@ void freeCylinderBinningResources(CylinderBinningResources* r) {
     if (r->d_temp_sort64) cudaFree(r->d_temp_sort64);
     if (r->d_temp_rle) cudaFree(r->d_temp_rle);
     if (r->d_temp_scan) cudaFree(r->d_temp_scan);
-    cudaFree(r->d_tileClassifyCounts);
+    cudaFree(r->d_wg_tileId);
+    cudaFree(r->d_wg_entityStart);
+    cudaFree(r->d_wg_entityCount);
+    cudaFree(r->d_wg_totalCount);
+    cudaFreeHost(r->h_wg_totalCount);
 }
 
 void resetCylinderBinningCounters(CylinderBinningResources* r, cudaStream_t stream) {
@@ -175,27 +189,36 @@ void executeCylinderPipelineBinning(
         cudaStreamSynchronize(stream);
         if (numRuns > numPairs) numRuns = numPairs;
 
-        buildTileOffsetsFromRLE(
-            r->d_unique_out, r->d_counts_out, numRuns, numPairs, r->totalTiles,
-            r->d_run_offsets, r->d_tile_offsets,
-            r->d_temp_scan, r->temp_scan_bytes, stream);
-        launchScatterAndFillTileOffsets(
-            r->d_unique_out, r->d_run_offsets, numRuns, numPairs, r->totalTiles,
-            r->d_tile_offsets, stream);
-    } else {
-        cudaMemsetAsync(r->d_tile_offsets, 0, (r->totalTiles + 1) * sizeof(unsigned int), stream);
+        // ExclusiveSum on counts -> run_offsets (start of each tile's entities in sorted array)
+        cub::DeviceScan::ExclusiveSum(
+            r->d_temp_scan, r->temp_scan_bytes,
+            r->d_counts_out, r->d_run_offsets,
+            numRuns, stream);
+
+        // Expand RLE runs into work-group dispatch list
+        cudaMemsetAsync(r->d_wg_totalCount, 0, sizeof(unsigned int), stream);
+        launchExpandWorkGroups(
+            r->d_unique_out, r->d_counts_out, r->d_run_offsets, numRuns,
+            r->d_wg_tileId, r->d_wg_entityStart, r->d_wg_entityCount,
+            r->d_wg_totalCount, stream);
+
+        // Read total work groups
+        cudaMemcpyAsync(r->h_wg_totalCount, r->d_wg_totalCount,
+            sizeof(unsigned int), cudaMemcpyDeviceToHost, stream);
+        cudaStreamSynchronize(stream);
+        unsigned int totalWorkGroups = *r->h_wg_totalCount;
+
+        // Launch tiled cylinder raster
+        if (totalWorkGroups > 0) {
+            launchTiledCylinderRasterWG(
+                d_cylinders, r->d_tile_entity_pairs_sorted,
+                r->d_wg_tileId, r->d_wg_entityStart, r->d_wg_entityCount,
+                totalWorkGroups, d_depthBuffer, outputImage, stream);
+        }
     }
 
     if (smallCount > 0) {
         launchSmallCylinderRaster(d_cylinders, r->d_smallIndices, smallCount, d_depthBuffer, outputImage, stream);
-    }
-
-    if (numPairs > 0) {
-        launchTiledCylinderRasterBinning(
-            d_cylinders, r->d_tile_offsets, r->d_tile_entity_pairs_sorted,
-            d_depthBuffer, outputImage, r->tilesX, r->tilesY,
-            r->d_unique_out, r->d_counts_out, r->d_run_offsets,
-            r->d_tileClassifyCounts, stream);
     }
 }
 

--- a/kernels/hybrid_binning/cylinder_pipeline_binning.cu
+++ b/kernels/hybrid_binning/cylinder_pipeline_binning.cu
@@ -56,7 +56,10 @@ extern "C" void launchTiledCylinderRasterBinning(
     const Cylinder* d_cylinders, const unsigned int* d_tile_offsets,
     const unsigned long long* d_tile_entity_pairs_sorted,
     unsigned int* d_depthBuffer, cudaSurfaceObject_t outputImage,
-    unsigned int tilesX, unsigned int tilesY, cudaStream_t stream);
+    unsigned int tilesX, unsigned int tilesY,
+    unsigned int* d_lightTileList, unsigned int* d_heavyTileIndices,
+    unsigned int* d_heavyBatchStarts, unsigned int* d_tileClassifyCounts,
+    cudaStream_t stream);
 
 #define CUDA_CHECK(call) do { cudaError_t e = call; if (e != cudaSuccess) printf("CUDA error %d: %s\n", e, cudaGetErrorString(e)); } while(0)
 
@@ -100,6 +103,7 @@ void initCylinderBinningResources(CylinderBinningResources* r, int maxCylinders,
     if (r->temp_sort64_bytes > 0) CUDA_CHECK(cudaMalloc(&r->d_temp_sort64, r->temp_sort64_bytes));
     if (r->temp_rle_bytes > 0) CUDA_CHECK(cudaMalloc(&r->d_temp_rle, r->temp_rle_bytes));
     if (r->temp_scan_bytes > 0) CUDA_CHECK(cudaMalloc(&r->d_temp_scan, r->temp_scan_bytes));
+    CUDA_CHECK(cudaMalloc(&r->d_tileClassifyCounts, 2 * sizeof(unsigned int)));
 }
 
 void freeCylinderBinningResources(CylinderBinningResources* r) {
@@ -121,6 +125,7 @@ void freeCylinderBinningResources(CylinderBinningResources* r) {
     if (r->d_temp_sort64) cudaFree(r->d_temp_sort64);
     if (r->d_temp_rle) cudaFree(r->d_temp_rle);
     if (r->d_temp_scan) cudaFree(r->d_temp_scan);
+    cudaFree(r->d_tileClassifyCounts);
 }
 
 void resetCylinderBinningCounters(CylinderBinningResources* r, cudaStream_t stream) {
@@ -188,7 +193,9 @@ void executeCylinderPipelineBinning(
     if (numPairs > 0) {
         launchTiledCylinderRasterBinning(
             d_cylinders, r->d_tile_offsets, r->d_tile_entity_pairs_sorted,
-            d_depthBuffer, outputImage, r->tilesX, r->tilesY, stream);
+            d_depthBuffer, outputImage, r->tilesX, r->tilesY,
+            r->d_unique_out, r->d_counts_out, r->d_run_offsets,
+            r->d_tileClassifyCounts, stream);
     }
 }
 

--- a/kernels/hybrid_binning/cylinder_pipeline_binning.cuh
+++ b/kernels/hybrid_binning/cylinder_pipeline_binning.cuh
@@ -38,6 +38,7 @@ struct CylinderBinningResources {
     int tilesX;
     int tilesY;
     int totalTiles;
+    unsigned int* d_tileClassifyCounts; // [0]=lightCount, [1]=heavyCount
 };
 
 void initCylinderBinningResources(CylinderBinningResources* r, int maxCylinders, int tilesX, int tilesY, int totalTiles, int avgEntitiesPerTile = 0);

--- a/kernels/hybrid_binning/cylinder_pipeline_binning.cuh
+++ b/kernels/hybrid_binning/cylinder_pipeline_binning.cuh
@@ -38,7 +38,13 @@ struct CylinderBinningResources {
     int tilesX;
     int tilesY;
     int totalTiles;
-    unsigned int* d_tileClassifyCounts; // [0]=lightCount, [1]=heavyCount
+    // Work-group expansion buffers
+    unsigned int* d_wg_tileId;       ///< tile index for each work group
+    unsigned int* d_wg_entityStart;  ///< start offset in sorted pairs for each WG
+    unsigned int* d_wg_entityCount;  ///< entity count per WG (<= SHARED_BATCH_SIZE)
+    unsigned int* d_wg_totalCount;   ///< single uint: atomicAdd counter for total WGs
+    unsigned int* h_wg_totalCount;   ///< pinned host copy of total WG count
+    int maxWorkGroups;               ///< allocated size of WG arrays
 };
 
 void initCylinderBinningResources(CylinderBinningResources* r, int maxCylinders, int tilesX, int tilesY, int totalTiles, int avgEntitiesPerTile = 0);

--- a/kernels/hybrid_binning/small_entity_raster.cu
+++ b/kernels/hybrid_binning/small_entity_raster.cu
@@ -60,10 +60,8 @@ __device__ inline glm::vec4 iCylinder(const glm::vec3& ro, const glm::vec3& rd,
     return glm::vec4(-1.0f);
 }
 
-__device__ inline glm::vec3 computeRayDirection(int px, int py, float fovTan, float halfFovTan) {
-    glm::vec2 p = (-glm::vec2(hybridCst.screenWidth, hybridCst.screenHeight) +
-                   2.0f * glm::vec2(px, py)) / glm::vec2(hybridCst.screenWidth, hybridCst.screenHeight);
-    return glm::normalize(p.x * hybridCst.right * halfFovTan + p.y * hybridCst.up * fovTan + hybridCst.front);
+__device__ inline glm::vec3 fastNormalize(const glm::vec3& v) {
+    return v * rsqrtf(glm::dot(v, v));
 }
 
 __global__ void smallSphereRasterKernel(
@@ -76,7 +74,7 @@ __global__ void smallSphereRasterKernel(
     unsigned int idx = blockIdx.x * blockDim.x + threadIdx.x;
     if (idx >= smallSphereCount) return;
 
-    unsigned int sphereIdx = smallSphereIndices[idx];
+    unsigned int sphereIdx = __ldg(&smallSphereIndices[idx]);
 
     glm::vec4 spherePosR = spheres[sphereIdx];
     glm::vec3 spherePos = glm::vec3(spherePosR);
@@ -124,31 +122,26 @@ __global__ void smallSphereRasterKernel(
     float dify = float(screenMaxY - screenMinY);
     if (difx * dify <= 2.0f) return;
 
-    float aspectRatio = __fdividef(float(hybridCst.screenWidth), float(hybridCst.screenHeight));
-    float fovRad = glm::radians(hybridCst.fov);
-    float fovTan = __tanf(fovRad * 0.5f);
-    float halfFovTan = fovTan * aspectRatio;
-
-
     float proj22 = hybridCst.proj[2][2];
     float proj32 = hybridCst.proj[3][2];
 
     for (int py = screenMinY; py < screenMaxY; py++) {
         glm::vec3 rayColStart = hybridCst.rayStart + (float)py * hybridCst.dy;
         for (int px = screenMinX; px < screenMaxX; px++) {
-            glm::vec3 rd = computeRayDirection(px, py, fovTan, halfFovTan);
+            glm::vec3 ray = rayColStart + (float)px * hybridCst.dx;
+            glm::vec3 rd = fastNormalize(ray.x * hybridCst.right + ray.y * hybridCst.up - ray.z * hybridCst.front);
             float t = iSphere(hybridCst.cameraPos, rd, spherePos, radius);
 
             if (t > 0.0f) {
-                glm::vec3 hit = (rayColStart + (float)px * hybridCst.dx) * t;
+                glm::vec3 hit = ray * t;
                 float depth = __fdividef(fmaf(hit.z, proj22, proj32), -hit.z);
                 unsigned int depthU = __float_as_uint(depth);
 
                 int pixelIdx = py * hybridCst.screenWidth + px;
                 unsigned int old = atomicMin(&depthBuffer[pixelIdx], depthU);
                 if (__uint_as_float(old) > depth) {
-                    glm::vec3 normal = glm::normalize(hybridCst.cameraPos + rd * t - glm::vec3(spherePosR));
-                    float lambert = fmaxf(0.0f, glm::dot(normal, -glm::normalize(rd * t)));
+                    glm::vec3 normal = fastNormalize(hybridCst.cameraPos + rd * t - glm::vec3(spherePosR));
+                    float lambert = fmaxf(0.0f, glm::dot(normal, -rd));
                     glm::vec3 color = glm::vec3(atomsColor[0], atomsColor[1], atomsColor[2]) * lambert * diffuse;
                     uchar4 ucharColor = make_uchar4(
                         (unsigned char)(color.x * 255.0f),
@@ -170,7 +163,7 @@ __global__ void smallCylinderRasterKernel(
 {
     unsigned int idx = blockIdx.x * blockDim.x + threadIdx.x;
     if (idx >= smallCylinderCount) return;
-    unsigned int cylIdx = smallCylinderIndices[idx];
+    unsigned int cylIdx = __ldg(&smallCylinderIndices[idx]);
     Cylinder cyl = cylinders[cylIdx];
     glm::vec3 pa = glm::vec3(cyl.pa_r), pb = glm::vec3(cyl.pb_r);
     float radius = cyl.pa_r.w;
@@ -247,50 +240,57 @@ __global__ void smallCylinderRasterKernel(
     }
     
 
-    float aspectRatio = fdividef(hybridCst.screenWidth, hybridCst.screenHeight);
-    float fovRad = glm::radians(hybridCst.fov);
-    float fovTan = __tanf(fovRad * 0.5f);
-    float halfFovTan = fovTan * aspectRatio;
-
     for (int py = fminf(hybridCst.screenHeight-1, maxY); py >= fmaxf(0, minY); --py)
     {
-        float xIntersections[4];
-        int intersections = 0;
 
+        
+        float fpy = float(py) + 0.5f; // Centro del pixel en Y
+        
+        // Encontrar startX y endX para esta fila específica
+        // Inicializamos invertidos para acumular min/max
+        float rowMinX = float(hybridCst.screenWidth);
+        float rowMaxX = -1.0f;
+        
+        // Recorremos las 4 aristas del polígono proyectado (unroll manual o loop corto)
         #pragma unroll 4
         for (int i = 0; i < 4; ++i) 
         {
-            const glm::vec2 a = projectedPoints[i];
-            const glm::vec2 b = projectedPoints[(i + 1) % 4];
+            glm::vec2 v1 = projectedPoints[i];
+            glm::vec2 v2 = projectedPoints[(i + 1) % 4];
 
-            if ((py >= a.y && py <= b.y) || (py >= b.y && py <= a.y)) 
+            // Comprobar si la linea cruza esta fila Y
+            // Nota: Usamos (>= y <) para evitar doble conteo en vértices exactos
+            bool crossing = (v1.y <= fpy && v2.y > fpy) || (v2.y <= fpy && v1.y > fpy);
+            
+            if (crossing) 
             {
-                float x = intersectX(a, b, py);
-                xIntersections[intersections] = x;
-                intersections++;
+                // Calcular intersección X sin llamadas a funciones externas
+                float t = (fpy - v1.y) / (v2.y - v1.y);
+                float intersectX = v1.x + t * (v2.x - v1.x);
+                
+                rowMinX = min(rowMinX, intersectX);
+                rowMaxX = max(rowMaxX, intersectX);
             }
         }
 
-        if (intersections >= 2)
-        {
-            float xMin = xIntersections[0];
-            float xMax = xIntersections[0];
+        // Convertir span a enteros y clampear
+        int startX = max(0, int(floor(rowMinX)));
+        int endX   = min(hybridCst.screenWidth - 1, int(ceil(rowMaxX)));
 
-            for (int i = 1; i < intersections; ++i) 
-            {
-                xMin = fminf(xMin, xIntersections[i]);
-                xMax = fmaxf(xMax, xIntersections[i]);
-            }
+        if (startX <= endX)
+        {
+
             glm::vec3 rayColStart = hybridCst.rayStart + (float)py * hybridCst.dy;
-            for (int px = max(0, __float2int_ru(xMin)); px <= min(__float2int_rd(xMax), hybridCst.screenWidth -1); ++px)
+            for (int px = max(0, startX); px <= min(endX, hybridCst.screenWidth -1); ++px)
             {
-                glm::vec3 rd = computeRayDirection(px, py, fovTan, halfFovTan);
+                glm::vec3 ray = rayColStart + (float)px * hybridCst.dx;
+                glm::vec3 rd = fastNormalize(ray.x * hybridCst.right + ray.y * hybridCst.up - ray.z * hybridCst.front);
                 glm::vec4 tnor = iCylinder(glm::vec3(hybridCst.cameraPos), rd, pa, pb, radius);
                 int index = px + hybridCst.screenWidth*py;
 
                 if (tnor.x > 0.0f) {
                     float t = tnor.x;
-                    glm::vec3 hit = (rayColStart + (float)px * hybridCst.dx) * t;
+                    glm::vec3 hit = ray * t;
                     float depth = __fdividef(fmaf(hit.z, hybridCst.proj[2][2], hybridCst.proj[3][2]), -hit.z);
 
                     unsigned int depthU = __float_as_uint(depth);
@@ -301,8 +301,8 @@ __global__ void smallCylinderRasterKernel(
                     // if we won (old > depth)
                     if (__uint_as_float(old) > depth) {
                         // own the pixel
-                        glm::vec3 normal = glm::normalize(glm::vec3(tnor.y, tnor.z, tnor.w));
-                        float lambert = glm::max(0.0f, glm::dot(normal, -glm::normalize(rd * t)));
+                        glm::vec3 normal = fastNormalize(glm::vec3(tnor.y, tnor.z, tnor.w));
+                        float lambert = fmaxf(0.0f, glm::dot(normal, -rd));
                         glm::vec3 color = glm::vec3(bondsColor[0], bondsColor[1], bondsColor[2]) * lambert * diffuse;
                         uchar4 ucharColor = make_uchar4(
                             (unsigned char)(color.x * 255.0f),

--- a/kernels/hybrid_binning/sphere_pipeline_binning.cu
+++ b/kernels/hybrid_binning/sphere_pipeline_binning.cu
@@ -39,25 +39,6 @@ extern "C" void sortPairs64AndBuildTileOffsets(
     size_t temp_scan_bytes,
     cudaStream_t stream);
 extern "C" void getRleTempStorageBytesForPairs64(size_t* out_bytes, int maxPairs);
-extern "C" void buildTileOffsetsFromRLE(
-    const unsigned int* d_unique_out,
-    const unsigned int* d_counts_out,
-    unsigned int num_runs,
-    unsigned int num_pairs,
-    unsigned int total_tiles,
-    unsigned int* d_run_offsets,
-    unsigned int* d_tile_offsets,
-    void* d_temp_scan,
-    size_t temp_scan_bytes,
-    cudaStream_t stream);
-extern "C" void launchScatterAndFillTileOffsets(
-    const unsigned int* d_unique_out,
-    const unsigned int* d_run_offsets,
-    unsigned int num_runs,
-    unsigned int num_pairs,
-    unsigned int total_tiles,
-    unsigned int* d_tile_offsets,
-    cudaStream_t stream);
 extern "C" void launchSmallSphereRaster(
     const glm::vec4* d_spheres,
     const unsigned int* d_smallSphereIndices,
@@ -65,18 +46,25 @@ extern "C" void launchSmallSphereRaster(
     unsigned int* d_depthBuffer,
     cudaSurfaceObject_t outputImage,
     cudaStream_t stream);
-extern "C" void launchTiledSphereRasterBinning(
+extern "C" void launchExpandWorkGroups(
+    const unsigned int* d_unique_out,
+    const unsigned int* d_counts_out,
+    const unsigned int* d_run_offsets,
+    unsigned int numRuns,
+    unsigned int* d_wg_tileId,
+    unsigned int* d_wg_entityStart,
+    unsigned int* d_wg_entityCount,
+    unsigned int* d_wg_totalCount,
+    cudaStream_t stream);
+extern "C" void launchTiledSphereRasterWG(
     const glm::vec4* d_spheres,
-    const unsigned int* d_tile_offsets,
     const unsigned long long* d_tile_entity_pairs_sorted,
+    const unsigned int* d_wg_tileId,
+    const unsigned int* d_wg_entityStart,
+    const unsigned int* d_wg_entityCount,
+    unsigned int totalWorkGroups,
     unsigned int* d_depthBuffer,
     cudaSurfaceObject_t outputImage,
-    unsigned int tilesX,
-    unsigned int tilesY,
-    unsigned int* d_lightTileList,
-    unsigned int* d_heavyTileIndices,
-    unsigned int* d_heavyBatchStarts,
-    unsigned int* d_tileClassifyCounts,
     cudaStream_t stream);
 
 #define CUDA_CHECK(call) do { cudaError_t e = call; if (e != cudaSuccess) printf("CUDA error %d: %s\n", e, cudaGetErrorString(e)); } while(0)
@@ -123,7 +111,14 @@ void initSphereBinningResources(SphereBinningResources* r, int maxSpheres, int t
     if (r->temp_sort64_bytes > 0) CUDA_CHECK(cudaMalloc(&r->d_temp_sort64, r->temp_sort64_bytes));
     if (r->temp_rle_bytes > 0) CUDA_CHECK(cudaMalloc(&r->d_temp_rle, r->temp_rle_bytes));
     if (r->temp_scan_bytes > 0) CUDA_CHECK(cudaMalloc(&r->d_temp_scan, r->temp_scan_bytes));
-    CUDA_CHECK(cudaMalloc(&r->d_tileClassifyCounts, 2 * sizeof(unsigned int)));
+
+    // Work-group expansion buffers
+    r->maxWorkGroups = r->maxPairs / SHARED_BATCH_SIZE + totalTiles;
+    CUDA_CHECK(cudaMalloc(&r->d_wg_tileId, r->maxWorkGroups * sizeof(unsigned int)));
+    CUDA_CHECK(cudaMalloc(&r->d_wg_entityStart, r->maxWorkGroups * sizeof(unsigned int)));
+    CUDA_CHECK(cudaMalloc(&r->d_wg_entityCount, r->maxWorkGroups * sizeof(unsigned int)));
+    CUDA_CHECK(cudaMalloc(&r->d_wg_totalCount, sizeof(unsigned int)));
+    CUDA_CHECK(cudaHostAlloc(&r->h_wg_totalCount, sizeof(unsigned int), cudaHostAllocDefault));
 }
 
 void freeSphereBinningResources(SphereBinningResources* r) {
@@ -145,7 +140,11 @@ void freeSphereBinningResources(SphereBinningResources* r) {
     if (r->d_temp_sort64) cudaFree(r->d_temp_sort64);
     if (r->d_temp_rle) cudaFree(r->d_temp_rle);
     if (r->d_temp_scan) cudaFree(r->d_temp_scan);
-    cudaFree(r->d_tileClassifyCounts);
+    cudaFree(r->d_wg_tileId);
+    cudaFree(r->d_wg_entityStart);
+    cudaFree(r->d_wg_entityCount);
+    cudaFree(r->d_wg_totalCount);
+    cudaFreeHost(r->h_wg_totalCount);
 }
 
 void resetSphereBinningCounters(SphereBinningResources* r, cudaStream_t stream) {
@@ -196,29 +195,36 @@ void executeSpherePipelineBinning(
         cudaStreamSynchronize(stream);
         if (numRuns > numPairs) numRuns = numPairs;
 
-        buildTileOffsetsFromRLE(
-            r->d_unique_out, r->d_counts_out, numRuns, numPairs, r->totalTiles,
-            r->d_run_offsets, r->d_tile_offsets,
-            r->d_temp_scan, r->temp_scan_bytes, stream);
-        launchScatterAndFillTileOffsets(
-            r->d_unique_out, r->d_run_offsets, numRuns, numPairs, r->totalTiles,
-            r->d_tile_offsets, stream);
-    } else {
-        cudaMemsetAsync(r->d_tile_offsets, 0, (r->totalTiles + 1) * sizeof(unsigned int), stream);
+        // ExclusiveSum on counts -> run_offsets (start of each tile's entities in sorted array)
+        cub::DeviceScan::ExclusiveSum(
+            r->d_temp_scan, r->temp_scan_bytes,
+            r->d_counts_out, r->d_run_offsets,
+            numRuns, stream);
+
+        // Expand RLE runs into work-group dispatch list
+        cudaMemsetAsync(r->d_wg_totalCount, 0, sizeof(unsigned int), stream);
+        launchExpandWorkGroups(
+            r->d_unique_out, r->d_counts_out, r->d_run_offsets, numRuns,
+            r->d_wg_tileId, r->d_wg_entityStart, r->d_wg_entityCount,
+            r->d_wg_totalCount, stream);
+
+        // Read total work groups
+        cudaMemcpyAsync(r->h_wg_totalCount, r->d_wg_totalCount,
+            sizeof(unsigned int), cudaMemcpyDeviceToHost, stream);
+        cudaStreamSynchronize(stream);
+        unsigned int totalWorkGroups = *r->h_wg_totalCount;
+
+        // Launch tiled sphere raster
+        if (totalWorkGroups > 0) {
+            launchTiledSphereRasterWG(
+                d_spheres, r->d_tile_entity_pairs_sorted,
+                r->d_wg_tileId, r->d_wg_entityStart, r->d_wg_entityCount,
+                totalWorkGroups, d_depthBuffer, outputImage, stream);
+        }
     }
 
     if (smallCount > 0) {
         launchSmallSphereRaster(d_spheres, r->d_smallIndices, smallCount, d_depthBuffer, outputImage, stream);
-    }
-
-    // TODO: Re-enable when sort/RLE/tile-offset pipeline is uncommented above.
-    // Without valid tile offsets, this reads garbage memory and crashes CUDA.
-    if (numPairs > 0) {
-        launchTiledSphereRasterBinning(
-            d_spheres, r->d_tile_offsets, r->d_tile_entity_pairs_sorted,
-            d_depthBuffer, outputImage, r->tilesX, r->tilesY,
-            r->d_unique_out, r->d_counts_out, r->d_run_offsets,
-            r->d_tileClassifyCounts, stream);
     }
 }
 

--- a/kernels/hybrid_binning/sphere_pipeline_binning.cu
+++ b/kernels/hybrid_binning/sphere_pipeline_binning.cu
@@ -73,6 +73,10 @@ extern "C" void launchTiledSphereRasterBinning(
     cudaSurfaceObject_t outputImage,
     unsigned int tilesX,
     unsigned int tilesY,
+    unsigned int* d_lightTileList,
+    unsigned int* d_heavyTileIndices,
+    unsigned int* d_heavyBatchStarts,
+    unsigned int* d_tileClassifyCounts,
     cudaStream_t stream);
 
 #define CUDA_CHECK(call) do { cudaError_t e = call; if (e != cudaSuccess) printf("CUDA error %d: %s\n", e, cudaGetErrorString(e)); } while(0)
@@ -119,6 +123,7 @@ void initSphereBinningResources(SphereBinningResources* r, int maxSpheres, int t
     if (r->temp_sort64_bytes > 0) CUDA_CHECK(cudaMalloc(&r->d_temp_sort64, r->temp_sort64_bytes));
     if (r->temp_rle_bytes > 0) CUDA_CHECK(cudaMalloc(&r->d_temp_rle, r->temp_rle_bytes));
     if (r->temp_scan_bytes > 0) CUDA_CHECK(cudaMalloc(&r->d_temp_scan, r->temp_scan_bytes));
+    CUDA_CHECK(cudaMalloc(&r->d_tileClassifyCounts, 2 * sizeof(unsigned int)));
 }
 
 void freeSphereBinningResources(SphereBinningResources* r) {
@@ -140,6 +145,7 @@ void freeSphereBinningResources(SphereBinningResources* r) {
     if (r->d_temp_sort64) cudaFree(r->d_temp_sort64);
     if (r->d_temp_rle) cudaFree(r->d_temp_rle);
     if (r->d_temp_scan) cudaFree(r->d_temp_scan);
+    cudaFree(r->d_tileClassifyCounts);
 }
 
 void resetSphereBinningCounters(SphereBinningResources* r, cudaStream_t stream) {
@@ -210,7 +216,9 @@ void executeSpherePipelineBinning(
     if (numPairs > 0) {
         launchTiledSphereRasterBinning(
             d_spheres, r->d_tile_offsets, r->d_tile_entity_pairs_sorted,
-            d_depthBuffer, outputImage, r->tilesX, r->tilesY, stream);
+            d_depthBuffer, outputImage, r->tilesX, r->tilesY,
+            r->d_unique_out, r->d_counts_out, r->d_run_offsets,
+            r->d_tileClassifyCounts, stream);
     }
 }
 

--- a/kernels/hybrid_binning/sphere_pipeline_binning.cuh
+++ b/kernels/hybrid_binning/sphere_pipeline_binning.cuh
@@ -37,6 +37,7 @@ struct SphereBinningResources {
     int tilesX;
     int tilesY;
     int totalTiles;
+    unsigned int* d_tileClassifyCounts; // [0]=lightCount, [1]=heavyCount
 };
 
 void initSphereBinningResources(SphereBinningResources* r, int maxSpheres, int tilesX, int tilesY, int totalTiles, int avgEntitiesPerTile = 0);

--- a/kernels/hybrid_binning/sphere_pipeline_binning.cuh
+++ b/kernels/hybrid_binning/sphere_pipeline_binning.cuh
@@ -37,7 +37,13 @@ struct SphereBinningResources {
     int tilesX;
     int tilesY;
     int totalTiles;
-    unsigned int* d_tileClassifyCounts; // [0]=lightCount, [1]=heavyCount
+    // Work-group expansion buffers
+    unsigned int* d_wg_tileId;       ///< tile index for each work group
+    unsigned int* d_wg_entityStart;  ///< start offset in sorted pairs for each WG
+    unsigned int* d_wg_entityCount;  ///< entity count per WG (≤ SHARED_BATCH_SIZE)
+    unsigned int* d_wg_totalCount;   ///< single uint: atomicAdd counter for total WGs
+    unsigned int* h_wg_totalCount;   ///< pinned host copy of total WG count
+    int maxWorkGroups;               ///< allocated size of WG arrays
 };
 
 void initSphereBinningResources(SphereBinningResources* r, int maxSpheres, int tilesX, int tilesY, int totalTiles, int avgEntitiesPerTile = 0);

--- a/kernels/hybrid_binning/tiled_raster_binning.cu
+++ b/kernels/hybrid_binning/tiled_raster_binning.cu
@@ -1,7 +1,9 @@
-/**
+﻿/**
  * @file tiled_raster_binning.cu
- * @brief Tiled rasterization using tileOffsets + sorted entity indices (no billboards).
- * Loads sphere/cylinder data from original buffers; recomputes bbox in shared memory.
+ * @brief Work-group expansion from RLE + unified tiled rasterization.
+ * After sort+RLE, each tile's entities are split into work groups of SHARED_BATCH.
+ * Each CUDA block processes one work group: loads entities into shared memory,
+ * ray-traces, and uses atomicMin on the depth buffer.
  */
 
 #include <cuda_runtime.h>
@@ -14,14 +16,8 @@ extern __constant__ HybridConstants hybridCst;
 
 #define TILE_SIZE 16
 #define SHARED_BATCH 64
-#define HEAVY_TILE_THRESHOLD 256
 
-/** Work-stealing counters for persistent-thread bin-split kernels.
- *  g_nextLightWorkItem: index into the compact light-tile list.
- *  g_nextHeavyWorkItem: index into the expanded heavy work-item list.
- *  Must be reset to 0 before each kernel launch. */
-__device__ unsigned int g_nextLightWorkItem;
-__device__ unsigned int g_nextHeavyWorkItem;
+// ─────────── Helpers ───────────
 
 __device__ inline float iSphereTiled(const glm::vec3& ro, const glm::vec3& rd,
                                      const glm::vec3& center, float radius) {
@@ -40,302 +36,16 @@ __device__ inline glm::vec3 computeRayDirTiled(int px, int py, float fovTan, flo
                           p.y * hybridCst.up * fovTan + hybridCst.front);
 }
 
-__device__ inline void computeSphereBBoxTiled(const glm::vec4& spherePosR,
-    int& bboxMinX, int& bboxMinY, int& bboxMaxX, int& bboxMaxY) 
-{
-    glm::vec3 spherePos = glm::vec3(spherePosR);
-    float radius = spherePosR.w;
-    glm::vec4 camSpace4 = hybridCst.view * glm::vec4(spherePos, 1.0f);
-    glm::vec3 cameraSpaceSphere = glm::vec3(camSpace4);
-    glm::vec3 normCamSpaceSphere = glm::normalize(cameraSpaceSphere);
-    glm::vec3 camImposPos = cameraSpaceSphere - normCamSpaceSphere * radius;
-
-    float dist = glm::length(cameraSpaceSphere) + 1e-6f;
-    float sinAngle = __fdividef(radius, dist);
-    float tanAngle = tanf(asinf(fminf(sinAngle, 0.999f)));
-    float quadScale = tanAngle * glm::length(camImposPos);
-
-    glm::vec3 upVec(0.0f, 1.0f, 0.0f);
-    glm::vec3 impU = glm::normalize(glm::cross(normCamSpaceSphere, upVec));
-    if (glm::length(impU) < 0.001f) impU = glm::vec3(1.0f, 0.0f, 0.0f);
-    glm::vec3 impV = glm::cross(impU, normCamSpaceSphere) * quadScale;
-    impU *= quadScale;
-
-    glm::vec3 corners[4] = {
-        camImposPos + impU + impV, camImposPos - impU + impV,
-        camImposPos + impU - impV, camImposPos - impU - impV
-    };
-
-    glm::vec2 minC(1e6f), maxC(-1e6f);
-    #pragma unroll
-    for (int i = 0; i < 4; i++) {
-        glm::vec4 clip = hybridCst.proj * glm::vec4(corners[i], 1.0f);
-        float iw = __fdividef(1.0f, clip.w);
-        float x = clip.x * iw;
-        float y = clip.y * iw;
-        minC.x = fminf(minC.x, x); minC.y = fminf(minC.y, y);
-        maxC.x = fmaxf(maxC.x, x); maxC.y = fmaxf(maxC.y, y);
-    }
-
-    bboxMinX = __float2int_rd(fmaf(minC.x, 0.5f, 0.5f) * hybridCst.screenWidth);
-    bboxMinY = __float2int_rd(fmaf(minC.y, 0.5f, 0.5f) * hybridCst.screenHeight);
-    bboxMaxX = __float2int_ru(fmaf(maxC.x, 0.5f, 0.5f) * hybridCst.screenWidth);
-    bboxMaxY = __float2int_ru(fmaf(maxC.y, 0.5f, 0.5f) * hybridCst.screenHeight);
-}
-
-/** Classify tiles into light (single-block) and heavy (multi-block) lists.
- *  - Empty tiles: skipped.
- *  - Light tiles (entityCount in (0, HEAVY_TILE_THRESHOLD]): 1 entry in d_lightTileList.
- *  - Heavy tiles (entityCount > HEAVY_TILE_THRESHOLD): ceil(entityCount/SHARED_BATCH)
- *    work-items in d_heavyTileIndices + d_heavyBatchStarts.
- *  d_tileClassifyCounts[0] = total light tiles, [1] = total heavy work items. */
-__global__ void classifyTilesKernel(
-    const unsigned int* __restrict__ d_tile_offsets,
-    unsigned int* __restrict__ d_lightTileList,
-    unsigned int* __restrict__ d_heavyTileIndices,
-    unsigned int* __restrict__ d_heavyBatchStarts,
-    unsigned int* __restrict__ d_tileClassifyCounts,
-    unsigned int totalTiles)
-{
-    unsigned int tid = blockIdx.x * blockDim.x + threadIdx.x;
-    if (tid >= totalTiles) return;
-    unsigned int entityCount = d_tile_offsets[tid + 1] - d_tile_offsets[tid];
-    if (entityCount == 0) return;
-
-    if (entityCount <= HEAVY_TILE_THRESHOLD) {
-        unsigned int idx = atomicAdd(&d_tileClassifyCounts[0], 1u);
-        d_lightTileList[idx] = tid;
-    } else {
-        unsigned int numBatches = (entityCount + SHARED_BATCH - 1) / SHARED_BATCH;
-        unsigned int base = atomicAdd(&d_tileClassifyCounts[1], numBatches);
-        for (unsigned int b = 0; b < numBatches; b++) {
-            d_heavyTileIndices[base + b] = tid;
-            d_heavyBatchStarts[base + b] = b * SHARED_BATCH;
-        }
-    }
-}
-
-/** Light sphere kernel: persistent threads, 1 tile per work-steal.
- *  Only ONE block ever processes a given tile, so no atomicMin needed. */
-__global__ void lightSphereRasterKernel(
-    const glm::vec4* __restrict__ d_spheres,
-    const unsigned int* __restrict__ d_tile_offsets,
-    const unsigned long long* __restrict__ d_tile_entity_pairs_sorted,
-    const unsigned int* __restrict__ d_lightTileList,
-    const unsigned int* __restrict__ d_tileClassifyCounts,
-    unsigned int* __restrict__ depthBuffer,
-    cudaSurfaceObject_t outputImage)
-{
-    const float aspectRatio = (float)hybridCst.screenWidth / (float)hybridCst.screenHeight;
-    const float fovRad = glm::radians(hybridCst.fov);
-    const float fovTan = tanf(fovRad * 0.5f);
-    const float halfFovTan = fovTan * aspectRatio;
-    const float proj22 = hybridCst.proj[2][2];
-    const float proj32 = hybridCst.proj[3][2];
-
-    __shared__ unsigned int s_workIdx;
-    __shared__ glm::vec4 shPosR[SHARED_BATCH];
-
-    const unsigned int totalLightTiles = d_tileClassifyCounts[0];
-
-    while (true) {
-        if (threadIdx.x == 0 && threadIdx.y == 0) {
-            s_workIdx = atomicAdd(&g_nextLightWorkItem, 1u);
-        }
-        __syncthreads();
-
-        if (s_workIdx >= totalLightTiles) return;
-
-        const unsigned int tileIdx = d_lightTileList[s_workIdx];
-        const unsigned int entityStart = d_tile_offsets[tileIdx];
-        const unsigned int entityEnd   = d_tile_offsets[tileIdx + 1];
-        const unsigned int entityCount = entityEnd - entityStart;
-
-        const unsigned int tileX = tileIdx % hybridCst.tilesX;
-        const unsigned int tileY = tileIdx / hybridCst.tilesX;
-        const int pixelX = tileX * TILE_SIZE + threadIdx.x;
-        const int pixelY = tileY * TILE_SIZE + threadIdx.y;
-        const bool validPixel = (pixelX < hybridCst.screenWidth && pixelY < hybridCst.screenHeight);
-
-        glm::vec3 rd, ray;
-        float minDepth = 1e30f;
-        if (validPixel) {
-            rd  = computeRayDirTiled(pixelX, pixelY, fovTan, halfFovTan);
-            ray = hybridCst.rayStart + (float)pixelX * hybridCst.dx + (float)pixelY * hybridCst.dy;
-            minDepth = __uint_as_float(depthBuffer[pixelY * hybridCst.screenWidth + pixelX]);
-        }
-        glm::vec3 finalColor(0.0f);
-        bool hasHit = false;
-
-        // Process ALL batches for this light tile within this single block
-        const unsigned int numBatches = (entityCount + SHARED_BATCH - 1) / SHARED_BATCH;
-        for (unsigned int batch = 0; batch < numBatches; batch++) {
-            unsigned int batchStart = batch * SHARED_BATCH;
-            unsigned int localIdx = threadIdx.y * TILE_SIZE + threadIdx.x;
-            if (localIdx < SHARED_BATCH) {
-                unsigned int entityIdx = batchStart + localIdx;
-                if (entityIdx < entityCount) {
-                    unsigned long long pair = d_tile_entity_pairs_sorted[entityStart + entityIdx];
-                    unsigned int sphereIndex = (unsigned int)(pair & 0xFFFFFFFFu);
-                    shPosR[localIdx] = d_spheres[sphereIndex];
-                }
-            }
-            __syncthreads();
-
-            if (validPixel) {
-                unsigned int batchCount = min(SHARED_BATCH, entityCount - batchStart);
-                for (unsigned int i = 0; i < batchCount; i++) {
-                    glm::vec4 posR = shPosR[i];
-                    float t = iSphereTiled(hybridCst.cameraPos, rd, glm::vec3(posR), posR.w);
-                    if (t > 0.0f) {
-                        glm::vec3 hit = ray * t;
-                        float depth = __fdividef(fmaf(hit.z, proj22, proj32), -hit.z);
-                        if (depth < minDepth) {
-                            minDepth = depth;
-                            hasHit = true;
-                            glm::vec3 worldHit = hybridCst.cameraPos + rd * t;
-                            glm::vec3 normal = glm::normalize(worldHit - glm::vec3(posR));
-                            float lambert = fmaxf(0.0f, glm::dot(normal, -glm::normalize(rd * t)));
-                            finalColor = glm::vec3(atomsColor[0], atomsColor[1], atomsColor[2]) * lambert * diffuse;
-                        }
-                    }
-                }
-            }
-            __syncthreads();
-        }
-
-        // Single block owns this tile — direct write, no atomicMin
-        if (validPixel && hasHit) {
-            int pixelIdx = pixelY * hybridCst.screenWidth + pixelX;
-            unsigned int depthU = __float_as_uint(minDepth);
-            depthBuffer[pixelIdx] = depthU;
-            uchar4 pixel = make_uchar4(
-                (unsigned char)(finalColor.x * 255.0f),
-                (unsigned char)(finalColor.y * 255.0f),
-                (unsigned char)(finalColor.z * 255.0f), 255);
-            surf2Dwrite(pixel, outputImage, pixelX * sizeof(uchar4), pixelY);
-        }
-        __syncthreads();
-    }
-}
-
-/** Heavy sphere kernel: persistent threads, 1 batch per work-steal.
- *  Multiple blocks may process the same tile -> atomicMin on depth buffer. */
-__global__ void heavySphereRasterKernel(
-    const glm::vec4* __restrict__ d_spheres,
-    const unsigned int* __restrict__ d_tile_offsets,
-    const unsigned long long* __restrict__ d_tile_entity_pairs_sorted,
-    const unsigned int* __restrict__ d_heavyTileIndices,
-    const unsigned int* __restrict__ d_heavyBatchStarts,
-    const unsigned int* __restrict__ d_tileClassifyCounts,
-    unsigned int* __restrict__ depthBuffer,
-    cudaSurfaceObject_t outputImage)
-{
-    const float aspectRatio = (float)hybridCst.screenWidth / (float)hybridCst.screenHeight;
-    const float fovRad = glm::radians(hybridCst.fov);
-    const float fovTan = tanf(fovRad * 0.5f);
-    const float halfFovTan = fovTan * aspectRatio;
-    const float proj22 = hybridCst.proj[2][2];
-    const float proj32 = hybridCst.proj[3][2];
-
-    __shared__ unsigned int s_workIdx;
-    __shared__ unsigned int s_tileIdx;
-    __shared__ unsigned int s_batchStart;
-    __shared__ unsigned int s_batchCount;
-    __shared__ glm::vec4 shPosR[SHARED_BATCH];
-
-    const unsigned int totalHeavyWorkItems = d_tileClassifyCounts[1];
-
-    while (true) {
-        if (threadIdx.x == 0 && threadIdx.y == 0) {
-            s_workIdx = atomicAdd(&g_nextHeavyWorkItem, 1u);
-        }
-        __syncthreads();
-
-        if (s_workIdx >= totalHeavyWorkItems) return;
-
-        // Decode which tile and which batch this work item represents
-        if (threadIdx.x == 0 && threadIdx.y == 0) {
-            unsigned int tileIdx = d_heavyTileIndices[s_workIdx];
-            unsigned int bStart  = d_heavyBatchStarts[s_workIdx];
-            unsigned int entityCount = d_tile_offsets[tileIdx + 1] - d_tile_offsets[tileIdx];
-            s_tileIdx    = tileIdx;
-            s_batchStart = bStart;
-            s_batchCount = min((unsigned int)SHARED_BATCH, entityCount - min(bStart, entityCount));
-        }
-        __syncthreads();
-
-        const unsigned int tileIdx    = s_tileIdx;
-        const unsigned int batchStart = s_batchStart;
-        const unsigned int batchCount = s_batchCount;
-
-        if (batchCount == 0) { __syncthreads(); continue; }
-
-        const unsigned int tileX = tileIdx % hybridCst.tilesX;
-        const unsigned int tileY = tileIdx / hybridCst.tilesX;
-        const int pixelX = tileX * TILE_SIZE + threadIdx.x;
-        const int pixelY = tileY * TILE_SIZE + threadIdx.y;
-        const bool validPixel = (pixelX < hybridCst.screenWidth && pixelY < hybridCst.screenHeight);
-
-        // Load one batch of entities into shared memory
-        const unsigned int entityStart = d_tile_offsets[tileIdx];
-        const unsigned int entityCount = d_tile_offsets[tileIdx + 1] - entityStart;
-        const unsigned int localIdx = threadIdx.y * TILE_SIZE + threadIdx.x;
-        if (localIdx < SHARED_BATCH) {
-            unsigned int entityIdx = batchStart + localIdx;
-            if (entityIdx < entityCount) {
-                unsigned long long pair = d_tile_entity_pairs_sorted[entityStart + entityIdx];
-                unsigned int sphereIndex = (unsigned int)(pair & 0xFFFFFFFFu);
-                shPosR[localIdx] = d_spheres[sphereIndex];
-            }
-        }
-        __syncthreads();
-
-        // Ray-trace this single batch; atomicMin for depth since multiple blocks share the tile
-        if (validPixel) {
-            glm::vec3 rd  = computeRayDirTiled(pixelX, pixelY, fovTan, halfFovTan);
-            glm::vec3 ray = hybridCst.rayStart + (float)pixelX * hybridCst.dx + (float)pixelY * hybridCst.dy;
-            const int pixelIdx = pixelY * hybridCst.screenWidth + pixelX;
-
-            for (unsigned int i = 0; i < batchCount; i++) {
-                glm::vec4 posR = shPosR[i];
-                float t = iSphereTiled(hybridCst.cameraPos, rd, glm::vec3(posR), posR.w);
-                if (t > 0.0f) {
-                    glm::vec3 hit = ray * t;
-                    float depth = __fdividef(fmaf(hit.z, proj22, proj32), -hit.z);
-                    unsigned int depthU = __float_as_uint(depth);
-                    unsigned int old = atomicMin(&depthBuffer[pixelIdx], depthU);
-                    if (depthU < old) {
-                        glm::vec3 worldHit = hybridCst.cameraPos + rd * t;
-                        glm::vec3 normal = glm::normalize(worldHit - glm::vec3(posR));
-                        float lambert = fmaxf(0.0f, glm::dot(normal, -glm::normalize(rd * t)));
-                        glm::vec3 color = glm::vec3(atomsColor[0], atomsColor[1], atomsColor[2]) * lambert * diffuse;
-                        uchar4 pixel = make_uchar4(
-                            (unsigned char)(color.x * 255.0f),
-                            (unsigned char)(color.y * 255.0f),
-                            (unsigned char)(color.z * 255.0f), 255);
-                        surf2Dwrite(pixel, outputImage, pixelX * sizeof(uchar4), pixelY);
-                    }
-                }
-            }
-        }
-        __syncthreads();
-    }
-}
-
-
-
-// Cylinder: ray-cylinder and bbox from quad (simplified - reuse logic from hybrid tiled)
 __device__ inline glm::vec4 iCylinderTiled(const glm::vec3& ro, const glm::vec3& rd,
-    const glm::vec3& pa, const glm::vec3& pb, float ra) 
-    {
+    const glm::vec3& pa, const glm::vec3& pb, float ra)
+{
     glm::vec3 ba = pb - pa, oc = ro - pa;
     float baba = glm::dot(ba, ba), bard = glm::dot(ba, rd), baoc = glm::dot(ba, oc);
-    
+
     float k2 = fmaf(bard, -bard, baba);
     float k1 = fmaf(glm::dot(oc,rd), baba, -baoc*bard);
     float k0 = fmaf(baba, glm::dot(oc,oc), fmaf(- ra*ra, baba, -baoc*baoc));
-    
+
     float h = fmaf(k1, k1, -k2*k0);
     if (h < 0.0f) return glm::vec4(-1.0f);
     h = sqrtf(h);
@@ -345,118 +55,76 @@ __device__ inline glm::vec4 iCylinderTiled(const glm::vec3& ro, const glm::vec3&
     return glm::vec4(-1.0f);
 }
 
-/** Light cylinder kernel: persistent threads, 1 tile per work-steal. No atomicMin. */
-__global__ void lightCylinderRasterKernel(
-    const Cylinder* __restrict__ d_cylinders,
-    const unsigned int* __restrict__ d_tile_offsets,
-    const unsigned long long* __restrict__ d_tile_entity_pairs_sorted,
-    const unsigned int* __restrict__ d_lightTileList,
-    const unsigned int* __restrict__ d_tileClassifyCounts,
-    unsigned int* __restrict__ depthBuffer,
-    cudaSurfaceObject_t outputImage)
+// ─────────── Work-group expansion from RLE results ───────────
+
+/**
+ * Expand RLE runs into a flat work-group dispatch list.
+ * Each RLE run i represents a tile with d_counts_out[i] entities starting
+ * at d_run_offsets[i] in the sorted pairs array.
+ * We split each run into ceil(count/SHARED_BATCH) work groups.
+ * Output: d_wg_tileId, d_wg_entityStart, d_wg_entityCount (one per WG).
+ * d_wg_totalCount is atomically incremented to give the total WG count.
+ */
+__global__ void expandWorkGroupsKernel(
+    const unsigned int* __restrict__ d_unique_out,
+    const unsigned int* __restrict__ d_counts_out,
+    const unsigned int* __restrict__ d_run_offsets,
+    unsigned int numRuns,
+    unsigned int* __restrict__ d_wg_tileId,
+    unsigned int* __restrict__ d_wg_entityStart,
+    unsigned int* __restrict__ d_wg_entityCount,
+    unsigned int* __restrict__ d_wg_totalCount)
 {
-    const float aspectRatio = (float)hybridCst.screenWidth / (float)hybridCst.screenHeight;
-    const float fovRad = glm::radians(hybridCst.fov);
-    const float fovTan = tanf(fovRad * 0.5f);
-    const float halfFovTan = fovTan * aspectRatio;
-    const float proj22 = hybridCst.proj[2][2];
-    const float proj32 = hybridCst.proj[3][2];
+    unsigned int runIdx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (runIdx >= numRuns) return;
 
-    __shared__ unsigned int s_workIdx;
-    __shared__ glm::vec4 shPa[SHARED_BATCH], shPb[SHARED_BATCH];
+    unsigned int tileId    = d_unique_out[runIdx];
+    unsigned int count     = d_counts_out[runIdx];
+    unsigned int runStart  = d_run_offsets[runIdx];
+    unsigned int numWG     = (count + SHARED_BATCH - 1) / SHARED_BATCH;
 
-    const unsigned int totalLightTiles = d_tileClassifyCounts[0];
+    unsigned int baseSlot = atomicAdd(d_wg_totalCount, numWG);
 
-    while (true) {
-        if (threadIdx.x == 0 && threadIdx.y == 0) {
-            s_workIdx = atomicAdd(&g_nextLightWorkItem, 1u);
-        }
-        __syncthreads();
+    for (unsigned int g = 0; g < numWG; g++) {
+        unsigned int wgStart = g * SHARED_BATCH;
+        unsigned int wgCount = min((unsigned int)SHARED_BATCH, count - wgStart);
+        d_wg_tileId    [baseSlot + g] = tileId;
+        d_wg_entityStart[baseSlot + g] = runStart + wgStart;
+        d_wg_entityCount[baseSlot + g] = wgCount;
+    }
+}
 
-        if (s_workIdx >= totalLightTiles) return;
+__device__ inline void writeFragmentSafe(
+    unsigned int* depthBuffer, int pixelIdx,
+    float depth, const glm::vec3& color,
+    cudaSurfaceObject_t outputImage, int px, int py)
+{
+    unsigned int newDepth = __float_as_uint(depth);
+    unsigned int old = depthBuffer[pixelIdx];
 
-        const unsigned int tileIdx = d_lightTileList[s_workIdx];
-        const unsigned int entityStart = d_tile_offsets[tileIdx];
-        const unsigned int entityEnd   = d_tile_offsets[tileIdx + 1];
-        const unsigned int entityCount = entityEnd - entityStart;
-
-        const unsigned int tileX = tileIdx % hybridCst.tilesX;
-        const unsigned int tileY = tileIdx / hybridCst.tilesX;
-        const int pixelX = tileX * TILE_SIZE + threadIdx.x;
-        const int pixelY = tileY * TILE_SIZE + threadIdx.y;
-        const bool validPixel = (pixelX < hybridCst.screenWidth && pixelY < hybridCst.screenHeight);
-
-        glm::vec3 rd, ray;
-        float minDepth = 1e30f;
-        if (validPixel) {
-            rd  = computeRayDirTiled(pixelX, pixelY, fovTan, halfFovTan);
-            ray = hybridCst.rayStart + (float)pixelX * hybridCst.dx + (float)pixelY * hybridCst.dy;
-            minDepth = __uint_as_float(depthBuffer[pixelY * hybridCst.screenWidth + pixelX]);
-        }
-        glm::vec3 finalColor(0.0f);
-        bool hasHit = false;
-
-        const unsigned int numBatches = (entityCount + SHARED_BATCH - 1) / SHARED_BATCH;
-        for (unsigned int batch = 0; batch < numBatches; batch++) {
-            unsigned int batchStart = batch * SHARED_BATCH;
-            unsigned int localIdx = threadIdx.y * TILE_SIZE + threadIdx.x;
-            if (localIdx < SHARED_BATCH) {
-                unsigned int entityIdx = batchStart + localIdx;
-                if (entityIdx < entityCount) {
-                    unsigned long long pair = d_tile_entity_pairs_sorted[entityStart + entityIdx];
-                    unsigned int cylIndex = (unsigned int)(pair & 0xFFFFFFFFu);
-                    Cylinder cyl = d_cylinders[cylIndex];
-                    shPa[localIdx] = cyl.pa_r;
-                    shPb[localIdx] = cyl.pb_r;
-                }
-            }
-            __syncthreads();
-
-            if (validPixel) {
-                unsigned int batchCount = min(SHARED_BATCH, entityCount - batchStart);
-                for (unsigned int i = 0; i < batchCount; i++) {
-                    glm::vec3 pa = glm::vec3(shPa[i]), pb = glm::vec3(shPb[i]);
-                    float ra = shPa[i].w;
-                    glm::vec4 tnor = iCylinderTiled(hybridCst.cameraPos, rd, pa, pb, ra);
-                    if (tnor.x > 0.0f) {
-                        float t = tnor.x;
-                        glm::vec3 hit = ray * t;
-                        float depth = __fdividef(fmaf(hit.z, proj22, proj32), -hit.z);
-                        if (depth < minDepth) {
-                            minDepth = depth;
-                            hasHit = true;
-                            glm::vec3 normal = glm::normalize(glm::vec3(tnor.y, tnor.z, tnor.w));
-                            float lambert = glm::max(0.0f, glm::dot(normal, -glm::normalize(rd * t)));
-                            finalColor = glm::vec3(bondsColor[0], bondsColor[1], bondsColor[2]) * lambert * diffuse;
-                        }
-                    }
-                }
-            }
-            __syncthreads();
-        }
-
-        if (validPixel && hasHit) {
-            int pixelIdx = pixelY * hybridCst.screenWidth + pixelX;
-            unsigned int depthU = __float_as_uint(minDepth);
-            depthBuffer[pixelIdx] = depthU;
+    while (__uint_as_float(old) > depth) {
+        unsigned int assumed = old;
+        old = atomicCAS(&depthBuffer[pixelIdx], assumed, newDepth);
+        if (old == assumed) {
             uchar4 pixel = make_uchar4(
-                (unsigned char)(finalColor.x * 255.0f),
-                (unsigned char)(finalColor.y * 255.0f),
-                (unsigned char)(finalColor.z * 255.0f), 255);
-            surf2Dwrite(pixel, outputImage, pixelX * sizeof(uchar4), pixelY);
+                (unsigned char)(color.x * 255.0f),
+                (unsigned char)(color.y * 255.0f),
+                (unsigned char)(color.z * 255.0f), 255);
+            surf2Dwrite(pixel, outputImage, px * sizeof(uchar4), py);
+            return;
         }
-        __syncthreads();
     }
 }
 
-/** Heavy cylinder kernel: persistent threads, 1 batch per work-steal. atomicMin depth. */
-__global__ void heavyCylinderRasterKernel(
-    const Cylinder* __restrict__ d_cylinders,
-    const unsigned int* __restrict__ d_tile_offsets,
+
+// ─────────── Sphere tiled raster (one block per work group) ───────────
+
+__global__ void tiledSphereRasterWGKernel(
+    const glm::vec4* __restrict__ d_spheres,
     const unsigned long long* __restrict__ d_tile_entity_pairs_sorted,
-    const unsigned int* __restrict__ d_heavyTileIndices,
-    const unsigned int* __restrict__ d_heavyBatchStarts,
-    const unsigned int* __restrict__ d_tileClassifyCounts,
+    const unsigned int* __restrict__ d_wg_tileId,
+    const unsigned int* __restrict__ d_wg_entityStart,
+    const unsigned int* __restrict__ d_wg_entityCount,
     unsigned int* __restrict__ depthBuffer,
     cudaSurfaceObject_t outputImage)
 {
@@ -467,197 +135,203 @@ __global__ void heavyCylinderRasterKernel(
     const float proj22 = hybridCst.proj[2][2];
     const float proj32 = hybridCst.proj[3][2];
 
-    __shared__ unsigned int s_workIdx;
-    __shared__ unsigned int s_tileIdx;
-    __shared__ unsigned int s_batchStart;
-    __shared__ unsigned int s_batchCount;
+    __shared__ glm::vec4 shPosR[SHARED_BATCH];
+
+    const unsigned int wgIdx       = blockIdx.x;
+    const unsigned int tileIdx     = d_wg_tileId[wgIdx];
+    const unsigned int entityStart = d_wg_entityStart[wgIdx];
+    const unsigned int entityCount = d_wg_entityCount[wgIdx];
+
+    const unsigned int tileX  = tileIdx % hybridCst.tilesX;
+    const unsigned int tileY  = tileIdx / hybridCst.tilesX;
+    const int pixelX = tileX * TILE_SIZE + threadIdx.x;
+    const int pixelY = tileY * TILE_SIZE + threadIdx.y;
+    const bool validPixel = (pixelX < hybridCst.screenWidth && pixelY < hybridCst.screenHeight);
+
+    bool hasHit = false;
+    glm::vec3 finalColor = glm::vec3(0.0f);
+    float finalDepth = __uint_as_float(depthBuffer[pixelY * hybridCst.screenWidth + pixelX]);
+
+    // Load entities into shared memory
+    const unsigned int localIdx = threadIdx.y * TILE_SIZE + threadIdx.x;
+    if (localIdx < SHARED_BATCH && localIdx < entityCount) {
+        unsigned long long pair = d_tile_entity_pairs_sorted[entityStart + localIdx];
+        unsigned int sphereIndex = (unsigned int)(pair & 0xFFFFFFFFu);
+        shPosR[localIdx] = d_spheres[sphereIndex];
+    }
+    __syncthreads();
+
+    // Ray-trace; atomicMin since multiple blocks may share a tile
+    if (!validPixel) return;
+
+    glm::vec3 rd  = computeRayDirTiled(pixelX, pixelY, fovTan, halfFovTan);
+    glm::vec3 ray = hybridCst.rayStart + (float)pixelX * hybridCst.dx + (float)pixelY * hybridCst.dy;
+    const int pixelIdx = pixelY * hybridCst.screenWidth + pixelX;
+
+    for (unsigned int i = 0; i < entityCount; i++) {
+        glm::vec4 posR = shPosR[i];
+        float t = iSphereTiled(hybridCst.cameraPos, rd, glm::vec3(posR), posR.w);
+        if (t > 0.0f) {
+            glm::vec3 hit = ray * t;
+            float depth = __fdividef(fmaf(hit.z, proj22, proj32), -hit.z);
+            
+            if (depth < finalDepth) {
+                hasHit = true;
+                glm::vec3 worldHit = hybridCst.cameraPos + rd * t;
+                glm::vec3 normal = glm::normalize(worldHit - glm::vec3(posR));
+                float lambert = fmaxf(0.0f, glm::dot(normal, -glm::normalize(rd * t)));
+                finalColor = glm::vec3(atomsColor[0], atomsColor[1], atomsColor[2]) * lambert * diffuse;
+                finalDepth = depth;
+            }
+        }
+    }
+
+    if (hasHit)
+    {
+            writeFragmentSafe(depthBuffer, pixelIdx, finalDepth, finalColor,
+                          outputImage, pixelX, pixelY);
+    }
+    
+}
+
+// ─────────── Cylinder tiled raster (one block per work group) ───────────
+
+__global__ void tiledCylinderRasterWGKernel(
+    const Cylinder* __restrict__ d_cylinders,
+    const unsigned long long* __restrict__ d_tile_entity_pairs_sorted,
+    const unsigned int* __restrict__ d_wg_tileId,
+    const unsigned int* __restrict__ d_wg_entityStart,
+    const unsigned int* __restrict__ d_wg_entityCount,
+    unsigned int* __restrict__ depthBuffer,
+    cudaSurfaceObject_t outputImage)
+{
+    const float aspectRatio = (float)hybridCst.screenWidth / (float)hybridCst.screenHeight;
+    const float fovRad = glm::radians(hybridCst.fov);
+    const float fovTan = tanf(fovRad * 0.5f);
+    const float halfFovTan = fovTan * aspectRatio;
+    const float proj22 = hybridCst.proj[2][2];
+    const float proj32 = hybridCst.proj[3][2];
+
+    
     __shared__ glm::vec4 shPa[SHARED_BATCH], shPb[SHARED_BATCH];
 
-    const unsigned int totalHeavyWorkItems = d_tileClassifyCounts[1];
+    const unsigned int wgIdx       = blockIdx.x;
+    const unsigned int tileIdx     = d_wg_tileId[wgIdx];
+    const unsigned int entityStart = d_wg_entityStart[wgIdx];
+    const unsigned int entityCount = d_wg_entityCount[wgIdx];
 
-    while (true) {
-        if (threadIdx.x == 0 && threadIdx.y == 0) {
-            s_workIdx = atomicAdd(&g_nextHeavyWorkItem, 1u);
-        }
-        __syncthreads();
+    const unsigned int tileX  = tileIdx % hybridCst.tilesX;
+    const unsigned int tileY  = tileIdx / hybridCst.tilesX;
+    const int pixelX = tileX * TILE_SIZE + threadIdx.x;
+    const int pixelY = tileY * TILE_SIZE + threadIdx.y;
+    const bool validPixel = (pixelX < hybridCst.screenWidth && pixelY < hybridCst.screenHeight);
+    
+    bool hasHit = false;
+    glm::vec3 finalColor = glm::vec3(0.0f);
+    float finalDepth = __uint_as_float(depthBuffer[pixelY * hybridCst.screenWidth + pixelX]); 
 
-        if (s_workIdx >= totalHeavyWorkItems) return;
+    // Load entities into shared memory
+    const unsigned int localIdx = threadIdx.y * TILE_SIZE + threadIdx.x;
+    if (localIdx < SHARED_BATCH && localIdx < entityCount) {
+        unsigned long long pair = d_tile_entity_pairs_sorted[entityStart + localIdx];
+        unsigned int cylIndex = (unsigned int)(pair & 0xFFFFFFFFu);
+        Cylinder cyl = d_cylinders[cylIndex];
+        shPa[localIdx] = cyl.pa_r;
+        shPb[localIdx] = cyl.pb_r;
+    }
+    __syncthreads();
 
-        if (threadIdx.x == 0 && threadIdx.y == 0) {
-            unsigned int tileIdx = d_heavyTileIndices[s_workIdx];
-            unsigned int bStart  = d_heavyBatchStarts[s_workIdx];
-            unsigned int entityCount = d_tile_offsets[tileIdx + 1] - d_tile_offsets[tileIdx];
-            s_tileIdx    = tileIdx;
-            s_batchStart = bStart;
-            s_batchCount = min((unsigned int)SHARED_BATCH, entityCount - min(bStart, entityCount));
-        }
-        __syncthreads();
+    // Ray-trace; atomicMin since multiple blocks may share a tile
+    if (!validPixel) return;
 
-        const unsigned int tileIdx    = s_tileIdx;
-        const unsigned int batchStart = s_batchStart;
-        const unsigned int batchCount = s_batchCount;
+    glm::vec3 rd  = computeRayDirTiled(pixelX, pixelY, fovTan, halfFovTan);
+    glm::vec3 ray = hybridCst.rayStart + (float)pixelX * hybridCst.dx + (float)pixelY * hybridCst.dy;
+    const int pixelIdx = pixelY * hybridCst.screenWidth + pixelX;
 
-        if (batchCount == 0) { __syncthreads(); continue; }
-
-        const unsigned int tileX = tileIdx % hybridCst.tilesX;
-        const unsigned int tileY = tileIdx / hybridCst.tilesX;
-        const int pixelX = tileX * TILE_SIZE + threadIdx.x;
-        const int pixelY = tileY * TILE_SIZE + threadIdx.y;
-        const bool validPixel = (pixelX < hybridCst.screenWidth && pixelY < hybridCst.screenHeight);
-
-        const unsigned int entityStart = d_tile_offsets[tileIdx];
-        const unsigned int entityCount = d_tile_offsets[tileIdx + 1] - entityStart;
-        const unsigned int localIdx = threadIdx.y * TILE_SIZE + threadIdx.x;
-        if (localIdx < SHARED_BATCH) {
-            unsigned int entityIdx = batchStart + localIdx;
-            if (entityIdx < entityCount) {
-                unsigned long long pair = d_tile_entity_pairs_sorted[entityStart + entityIdx];
-                unsigned int cylIndex = (unsigned int)(pair & 0xFFFFFFFFu);
-                Cylinder cyl = d_cylinders[cylIndex];
-                shPa[localIdx] = cyl.pa_r;
-                shPb[localIdx] = cyl.pb_r;
+    for (unsigned int i = 0; i < entityCount; i++) {
+        glm::vec3 pa = glm::vec3(shPa[i]), pb = glm::vec3(shPb[i]);
+        float ra = shPa[i].w;
+        glm::vec4 tnor = iCylinderTiled(hybridCst.cameraPos, rd, pa, pb, ra);
+        if (tnor.x > 0.0f) {
+            float t = tnor.x;
+            glm::vec3 hit = ray * t;
+            float depth = __fdividef(fmaf(hit.z, proj22, proj32), -hit.z);
+            
+            if (depth < finalDepth) {
+                hasHit = true;
+                glm::vec3 normal = glm::normalize(glm::vec3(tnor.y, tnor.z, tnor.w));
+                float lambert = glm::max(0.0f, glm::dot(normal, -glm::normalize(rd * t)));
+                finalColor = glm::vec3(bondsColor[0], bondsColor[1], bondsColor[2]) * lambert * diffuse;
+                finalDepth = depth;
             }
         }
-        __syncthreads();
-
-        if (validPixel) {
-            glm::vec3 rd  = computeRayDirTiled(pixelX, pixelY, fovTan, halfFovTan);
-            glm::vec3 ray = hybridCst.rayStart + (float)pixelX * hybridCst.dx + (float)pixelY * hybridCst.dy;
-            const int pixelIdx = pixelY * hybridCst.screenWidth + pixelX;
-
-            for (unsigned int i = 0; i < batchCount; i++) {
-                glm::vec3 pa = glm::vec3(shPa[i]), pb = glm::vec3(shPb[i]);
-                float ra = shPa[i].w;
-                glm::vec4 tnor = iCylinderTiled(hybridCst.cameraPos, rd, pa, pb, ra);
-                if (tnor.x > 0.0f) {
-                    float t = tnor.x;
-                    glm::vec3 hit = ray * t;
-                    float depth = __fdividef(fmaf(hit.z, proj22, proj32), -hit.z);
-                    unsigned int depthU = __float_as_uint(depth);
-                    unsigned int old = atomicMin(&depthBuffer[pixelIdx], depthU);
-                    if (depthU < old) {
-                        glm::vec3 normal = glm::normalize(glm::vec3(tnor.y, tnor.z, tnor.w));
-                        float lambert = glm::max(0.0f, glm::dot(normal, -glm::normalize(rd * t)));
-                        glm::vec3 color = glm::vec3(bondsColor[0], bondsColor[1], bondsColor[2]) * lambert * diffuse;
-                        uchar4 pixel = make_uchar4(
-                            (unsigned char)(color.x * 255.0f),
-                            (unsigned char)(color.y * 255.0f),
-                            (unsigned char)(color.z * 255.0f), 255);
-                        surf2Dwrite(pixel, outputImage, pixelX * sizeof(uchar4), pixelY);
-                    }
-                }
-            }
-        }
-        __syncthreads();
     }
+
+    if (hasHit)
+    { 
+        writeFragmentSafe(depthBuffer, pixelIdx, finalDepth, finalColor,
+                        outputImage, pixelX, pixelY);   
+    }
+    
 }
 
-// Helper: query SM count (cached)
-static int getNumSMs() {
-    static int numSMs = 0;
-    if (numSMs == 0) {
-        int device = 0;
-        cudaGetDevice(&device);
-        cudaDeviceGetAttribute(&numSMs, cudaDevAttrMultiProcessorCount, device);
-    }
-    return numSMs;
+// ─────────── Launch wrappers (extern "C") ───────────
+
+extern "C" void launchExpandWorkGroups(
+    const unsigned int* d_unique_out,
+    const unsigned int* d_counts_out,
+    const unsigned int* d_run_offsets,
+    unsigned int numRuns,
+    unsigned int* d_wg_tileId,
+    unsigned int* d_wg_entityStart,
+    unsigned int* d_wg_entityCount,
+    unsigned int* d_wg_totalCount,
+    cudaStream_t stream)
+{
+    if (numRuns == 0) return;
+    int threads = 256;
+    int blocks = (numRuns + threads - 1) / threads;
+    expandWorkGroupsKernel<<<blocks, threads, 0, stream>>>(
+        d_unique_out, d_counts_out, d_run_offsets, numRuns,
+        d_wg_tileId, d_wg_entityStart, d_wg_entityCount, d_wg_totalCount);
 }
 
-extern "C" void launchTiledSphereRasterBinning(
+extern "C" void launchTiledSphereRasterWG(
     const glm::vec4* d_spheres,
-    const unsigned int* d_tile_offsets,
     const unsigned long long* d_tile_entity_pairs_sorted,
+    const unsigned int* d_wg_tileId,
+    const unsigned int* d_wg_entityStart,
+    const unsigned int* d_wg_entityCount,
+    unsigned int totalWorkGroups,
     unsigned int* d_depthBuffer,
     cudaSurfaceObject_t outputImage,
-    unsigned int tilesX,
-    unsigned int tilesY,
-    unsigned int* d_lightTileList,
-    unsigned int* d_heavyTileIndices,
-    unsigned int* d_heavyBatchStarts,
-    unsigned int* d_tileClassifyCounts,
     cudaStream_t stream)
 {
-    unsigned int totalTiles = tilesX * tilesY;
-
-    // Classify tiles into light and heavy lists
-    cudaMemsetAsync(d_tileClassifyCounts, 0, 2 * sizeof(unsigned int), stream);
-    {
-        int threads = 256;
-        int blocks = (totalTiles + threads - 1) / threads;
-        classifyTilesKernel<<<blocks, threads, 0, stream>>>(
-            d_tile_offsets, d_lightTileList, d_heavyTileIndices,
-            d_heavyBatchStarts, d_tileClassifyCounts, totalTiles);
-    }
-
-    int numSMs = getNumSMs();
+    if (totalWorkGroups == 0) return;
     dim3 block(TILE_SIZE, TILE_SIZE);
-    dim3 grid(numSMs * 2, 1);
-
-    // Light tiles: persistent threads, 1 tile per work-steal (no atomicMin)
-    {
-        unsigned int zero = 0;
-        cudaMemcpyToSymbolAsync(g_nextLightWorkItem, &zero, sizeof(unsigned int), 0, cudaMemcpyHostToDevice, stream);
-        lightSphereRasterKernel<<<grid, block, 0, stream>>>(
-            d_spheres, d_tile_offsets, d_tile_entity_pairs_sorted,
-            d_lightTileList, d_tileClassifyCounts,
-            d_depthBuffer, outputImage);
-    }
-
-    // Heavy tiles: persistent threads, 1 batch per work-steal (atomicMin depth)
-    {
-        unsigned int zero = 0;
-        cudaMemcpyToSymbolAsync(g_nextHeavyWorkItem, &zero, sizeof(unsigned int), 0, cudaMemcpyHostToDevice, stream);
-        heavySphereRasterKernel<<<grid, block, 0, stream>>>(
-            d_spheres, d_tile_offsets, d_tile_entity_pairs_sorted,
-            d_heavyTileIndices, d_heavyBatchStarts, d_tileClassifyCounts,
-            d_depthBuffer, outputImage);
-    }
+    dim3 grid(totalWorkGroups, 1);
+    tiledSphereRasterWGKernel<<<grid, block, 0, stream>>>(
+        d_spheres, d_tile_entity_pairs_sorted,
+        d_wg_tileId, d_wg_entityStart, d_wg_entityCount,
+        d_depthBuffer, outputImage);
 }
 
-extern "C" void launchTiledCylinderRasterBinning(
+extern "C" void launchTiledCylinderRasterWG(
     const Cylinder* d_cylinders,
-    const unsigned int* d_tile_offsets,
     const unsigned long long* d_tile_entity_pairs_sorted,
+    const unsigned int* d_wg_tileId,
+    const unsigned int* d_wg_entityStart,
+    const unsigned int* d_wg_entityCount,
+    unsigned int totalWorkGroups,
     unsigned int* d_depthBuffer,
     cudaSurfaceObject_t outputImage,
-    unsigned int tilesX,
-    unsigned int tilesY,
-    unsigned int* d_lightTileList,
-    unsigned int* d_heavyTileIndices,
-    unsigned int* d_heavyBatchStarts,
-    unsigned int* d_tileClassifyCounts,
     cudaStream_t stream)
 {
-    unsigned int totalTiles = tilesX * tilesY;
-
-    cudaMemsetAsync(d_tileClassifyCounts, 0, 2 * sizeof(unsigned int), stream);
-    {
-        int threads = 256;
-        int blocks = (totalTiles + threads - 1) / threads;
-        classifyTilesKernel<<<blocks, threads, 0, stream>>>(
-            d_tile_offsets, d_lightTileList, d_heavyTileIndices,
-            d_heavyBatchStarts, d_tileClassifyCounts, totalTiles);
-    }
-
-    int numSMs = getNumSMs();
+    if (totalWorkGroups == 0) return;
     dim3 block(TILE_SIZE, TILE_SIZE);
-    dim3 grid(numSMs * 2, 1);
-
-    {
-        unsigned int zero = 0;
-        cudaMemcpyToSymbolAsync(g_nextLightWorkItem, &zero, sizeof(unsigned int), 0, cudaMemcpyHostToDevice, stream);
-        lightCylinderRasterKernel<<<grid, block, 0, stream>>>(
-            d_cylinders, d_tile_offsets, d_tile_entity_pairs_sorted,
-            d_lightTileList, d_tileClassifyCounts,
-            d_depthBuffer, outputImage);
-    }
-
-    {
-        unsigned int zero = 0;
-        cudaMemcpyToSymbolAsync(g_nextHeavyWorkItem, &zero, sizeof(unsigned int), 0, cudaMemcpyHostToDevice, stream);
-        heavyCylinderRasterKernel<<<grid, block, 0, stream>>>(
-            d_cylinders, d_tile_offsets, d_tile_entity_pairs_sorted,
-            d_heavyTileIndices, d_heavyBatchStarts, d_tileClassifyCounts,
-            d_depthBuffer, outputImage);
-    }
+    dim3 grid(totalWorkGroups, 1);
+    tiledCylinderRasterWGKernel<<<grid, block, 0, stream>>>(
+        d_cylinders, d_tile_entity_pairs_sorted,
+        d_wg_tileId, d_wg_entityStart, d_wg_entityCount,
+        d_depthBuffer, outputImage);
 }

--- a/kernels/hybrid_binning/tiled_raster_binning.cu
+++ b/kernels/hybrid_binning/tiled_raster_binning.cu
@@ -7,7 +7,6 @@
 #include <cuda_runtime.h>
 #include <device_launch_parameters.h>
 #include <glm/glm.hpp>
-
 #include "hybrid_binning_types.h"
 #include "geometry/cylinder/cylinder.h"
 
@@ -15,6 +14,14 @@ extern __constant__ HybridConstants hybridCst;
 
 #define TILE_SIZE 16
 #define SHARED_BATCH 64
+#define HEAVY_TILE_THRESHOLD 256
+
+/** Work-stealing counters for persistent-thread bin-split kernels.
+ *  g_nextLightWorkItem: index into the compact light-tile list.
+ *  g_nextHeavyWorkItem: index into the expanded heavy work-item list.
+ *  Must be reset to 0 before each kernel launch. */
+__device__ unsigned int g_nextLightWorkItem;
+__device__ unsigned int g_nextHeavyWorkItem;
 
 __device__ inline float iSphereTiled(const glm::vec3& ro, const glm::vec3& rd,
                                      const glm::vec3& center, float radius) {
@@ -76,87 +83,243 @@ __device__ inline void computeSphereBBoxTiled(const glm::vec4& spherePosR,
     bboxMaxY = __float2int_ru(fmaf(maxC.y, 0.5f, 0.5f) * hybridCst.screenHeight);
 }
 
-__global__ void tiledSphereRasterBinningKernel(
+/** Classify tiles into light (single-block) and heavy (multi-block) lists.
+ *  - Empty tiles: skipped.
+ *  - Light tiles (entityCount in (0, HEAVY_TILE_THRESHOLD]): 1 entry in d_lightTileList.
+ *  - Heavy tiles (entityCount > HEAVY_TILE_THRESHOLD): ceil(entityCount/SHARED_BATCH)
+ *    work-items in d_heavyTileIndices + d_heavyBatchStarts.
+ *  d_tileClassifyCounts[0] = total light tiles, [1] = total heavy work items. */
+__global__ void classifyTilesKernel(
+    const unsigned int* __restrict__ d_tile_offsets,
+    unsigned int* __restrict__ d_lightTileList,
+    unsigned int* __restrict__ d_heavyTileIndices,
+    unsigned int* __restrict__ d_heavyBatchStarts,
+    unsigned int* __restrict__ d_tileClassifyCounts,
+    unsigned int totalTiles)
+{
+    unsigned int tid = blockIdx.x * blockDim.x + threadIdx.x;
+    if (tid >= totalTiles) return;
+    unsigned int entityCount = d_tile_offsets[tid + 1] - d_tile_offsets[tid];
+    if (entityCount == 0) return;
+
+    if (entityCount <= HEAVY_TILE_THRESHOLD) {
+        unsigned int idx = atomicAdd(&d_tileClassifyCounts[0], 1u);
+        d_lightTileList[idx] = tid;
+    } else {
+        unsigned int numBatches = (entityCount + SHARED_BATCH - 1) / SHARED_BATCH;
+        unsigned int base = atomicAdd(&d_tileClassifyCounts[1], numBatches);
+        for (unsigned int b = 0; b < numBatches; b++) {
+            d_heavyTileIndices[base + b] = tid;
+            d_heavyBatchStarts[base + b] = b * SHARED_BATCH;
+        }
+    }
+}
+
+/** Light sphere kernel: persistent threads, 1 tile per work-steal.
+ *  Only ONE block ever processes a given tile, so no atomicMin needed. */
+__global__ void lightSphereRasterKernel(
     const glm::vec4* __restrict__ d_spheres,
     const unsigned int* __restrict__ d_tile_offsets,
     const unsigned long long* __restrict__ d_tile_entity_pairs_sorted,
+    const unsigned int* __restrict__ d_lightTileList,
+    const unsigned int* __restrict__ d_tileClassifyCounts,
     unsigned int* __restrict__ depthBuffer,
     cudaSurfaceObject_t outputImage)
 {
-    const unsigned int tileX = blockIdx.x;
-    const unsigned int tileY = blockIdx.y;
-    const unsigned int tileIdx = tileY * hybridCst.tilesX + tileX;
-    const int pixelX = tileX * TILE_SIZE + threadIdx.x;
-    const int pixelY = tileY * TILE_SIZE + threadIdx.y;
-    if (pixelX >= hybridCst.screenWidth || pixelY >= hybridCst.screenHeight) return;
+    const float aspectRatio = (float)hybridCst.screenWidth / (float)hybridCst.screenHeight;
+    const float fovRad = glm::radians(hybridCst.fov);
+    const float fovTan = tanf(fovRad * 0.5f);
+    const float halfFovTan = fovTan * aspectRatio;
+    const float proj22 = hybridCst.proj[2][2];
+    const float proj32 = hybridCst.proj[3][2];
 
-    const unsigned int entityStart = d_tile_offsets[tileIdx];
-    const unsigned int entityEnd = d_tile_offsets[tileIdx + 1];
-    const unsigned int entityCount = entityEnd - entityStart;
-    if (entityCount == 0) return;
-
+    __shared__ unsigned int s_workIdx;
     __shared__ glm::vec4 shPosR[SHARED_BATCH];
 
-    float aspectRatio = (float)hybridCst.screenWidth / (float)hybridCst.screenHeight;
-    float fovRad = glm::radians(hybridCst.fov);
-    float fovTan = tanf(fovRad * 0.5f);
-    float halfFovTan = fovTan * aspectRatio;
+    const unsigned int totalLightTiles = d_tileClassifyCounts[0];
 
-    glm::vec3 ray = hybridCst.rayStart + (float)pixelX * hybridCst.dx + (float)pixelY * hybridCst.dy;
+    while (true) {
+        if (threadIdx.x == 0 && threadIdx.y == 0) {
+            s_workIdx = atomicAdd(&g_nextLightWorkItem, 1u);
+        }
+        __syncthreads();
 
-    glm::vec3 rd = computeRayDirTiled(pixelX, pixelY, fovTan, halfFovTan);
-    float minDepth = __uint_as_float(depthBuffer[pixelY * hybridCst.screenWidth + pixelX]);
-    glm::vec3 finalColor(0.0f);
-    bool hasHit = false;
+        if (s_workIdx >= totalLightTiles) return;
 
-    unsigned int numBatches = (entityCount + SHARED_BATCH - 1) / SHARED_BATCH;
-    for (unsigned int batch = 0; batch < numBatches; batch++) {
-        unsigned int batchStart = batch * SHARED_BATCH;
-        unsigned int localIdx = threadIdx.y * TILE_SIZE + threadIdx.x;
+        const unsigned int tileIdx = d_lightTileList[s_workIdx];
+        const unsigned int entityStart = d_tile_offsets[tileIdx];
+        const unsigned int entityEnd   = d_tile_offsets[tileIdx + 1];
+        const unsigned int entityCount = entityEnd - entityStart;
+
+        const unsigned int tileX = tileIdx % hybridCst.tilesX;
+        const unsigned int tileY = tileIdx / hybridCst.tilesX;
+        const int pixelX = tileX * TILE_SIZE + threadIdx.x;
+        const int pixelY = tileY * TILE_SIZE + threadIdx.y;
+        const bool validPixel = (pixelX < hybridCst.screenWidth && pixelY < hybridCst.screenHeight);
+
+        glm::vec3 rd, ray;
+        float minDepth = 1e30f;
+        if (validPixel) {
+            rd  = computeRayDirTiled(pixelX, pixelY, fovTan, halfFovTan);
+            ray = hybridCst.rayStart + (float)pixelX * hybridCst.dx + (float)pixelY * hybridCst.dy;
+            minDepth = __uint_as_float(depthBuffer[pixelY * hybridCst.screenWidth + pixelX]);
+        }
+        glm::vec3 finalColor(0.0f);
+        bool hasHit = false;
+
+        // Process ALL batches for this light tile within this single block
+        const unsigned int numBatches = (entityCount + SHARED_BATCH - 1) / SHARED_BATCH;
+        for (unsigned int batch = 0; batch < numBatches; batch++) {
+            unsigned int batchStart = batch * SHARED_BATCH;
+            unsigned int localIdx = threadIdx.y * TILE_SIZE + threadIdx.x;
+            if (localIdx < SHARED_BATCH) {
+                unsigned int entityIdx = batchStart + localIdx;
+                if (entityIdx < entityCount) {
+                    unsigned long long pair = d_tile_entity_pairs_sorted[entityStart + entityIdx];
+                    unsigned int sphereIndex = (unsigned int)(pair & 0xFFFFFFFFu);
+                    shPosR[localIdx] = d_spheres[sphereIndex];
+                }
+            }
+            __syncthreads();
+
+            if (validPixel) {
+                unsigned int batchCount = min(SHARED_BATCH, entityCount - batchStart);
+                for (unsigned int i = 0; i < batchCount; i++) {
+                    glm::vec4 posR = shPosR[i];
+                    float t = iSphereTiled(hybridCst.cameraPos, rd, glm::vec3(posR), posR.w);
+                    if (t > 0.0f) {
+                        glm::vec3 hit = ray * t;
+                        float depth = __fdividef(fmaf(hit.z, proj22, proj32), -hit.z);
+                        if (depth < minDepth) {
+                            minDepth = depth;
+                            hasHit = true;
+                            glm::vec3 worldHit = hybridCst.cameraPos + rd * t;
+                            glm::vec3 normal = glm::normalize(worldHit - glm::vec3(posR));
+                            float lambert = fmaxf(0.0f, glm::dot(normal, -glm::normalize(rd * t)));
+                            finalColor = glm::vec3(atomsColor[0], atomsColor[1], atomsColor[2]) * lambert * diffuse;
+                        }
+                    }
+                }
+            }
+            __syncthreads();
+        }
+
+        // Single block owns this tile — direct write, no atomicMin
+        if (validPixel && hasHit) {
+            int pixelIdx = pixelY * hybridCst.screenWidth + pixelX;
+            unsigned int depthU = __float_as_uint(minDepth);
+            depthBuffer[pixelIdx] = depthU;
+            uchar4 pixel = make_uchar4(
+                (unsigned char)(finalColor.x * 255.0f),
+                (unsigned char)(finalColor.y * 255.0f),
+                (unsigned char)(finalColor.z * 255.0f), 255);
+            surf2Dwrite(pixel, outputImage, pixelX * sizeof(uchar4), pixelY);
+        }
+        __syncthreads();
+    }
+}
+
+/** Heavy sphere kernel: persistent threads, 1 batch per work-steal.
+ *  Multiple blocks may process the same tile -> atomicMin on depth buffer. */
+__global__ void heavySphereRasterKernel(
+    const glm::vec4* __restrict__ d_spheres,
+    const unsigned int* __restrict__ d_tile_offsets,
+    const unsigned long long* __restrict__ d_tile_entity_pairs_sorted,
+    const unsigned int* __restrict__ d_heavyTileIndices,
+    const unsigned int* __restrict__ d_heavyBatchStarts,
+    const unsigned int* __restrict__ d_tileClassifyCounts,
+    unsigned int* __restrict__ depthBuffer,
+    cudaSurfaceObject_t outputImage)
+{
+    const float aspectRatio = (float)hybridCst.screenWidth / (float)hybridCst.screenHeight;
+    const float fovRad = glm::radians(hybridCst.fov);
+    const float fovTan = tanf(fovRad * 0.5f);
+    const float halfFovTan = fovTan * aspectRatio;
+    const float proj22 = hybridCst.proj[2][2];
+    const float proj32 = hybridCst.proj[3][2];
+
+    __shared__ unsigned int s_workIdx;
+    __shared__ unsigned int s_tileIdx;
+    __shared__ unsigned int s_batchStart;
+    __shared__ unsigned int s_batchCount;
+    __shared__ glm::vec4 shPosR[SHARED_BATCH];
+
+    const unsigned int totalHeavyWorkItems = d_tileClassifyCounts[1];
+
+    while (true) {
+        if (threadIdx.x == 0 && threadIdx.y == 0) {
+            s_workIdx = atomicAdd(&g_nextHeavyWorkItem, 1u);
+        }
+        __syncthreads();
+
+        if (s_workIdx >= totalHeavyWorkItems) return;
+
+        // Decode which tile and which batch this work item represents
+        if (threadIdx.x == 0 && threadIdx.y == 0) {
+            unsigned int tileIdx = d_heavyTileIndices[s_workIdx];
+            unsigned int bStart  = d_heavyBatchStarts[s_workIdx];
+            unsigned int entityCount = d_tile_offsets[tileIdx + 1] - d_tile_offsets[tileIdx];
+            s_tileIdx    = tileIdx;
+            s_batchStart = bStart;
+            s_batchCount = min((unsigned int)SHARED_BATCH, entityCount - min(bStart, entityCount));
+        }
+        __syncthreads();
+
+        const unsigned int tileIdx    = s_tileIdx;
+        const unsigned int batchStart = s_batchStart;
+        const unsigned int batchCount = s_batchCount;
+
+        if (batchCount == 0) { __syncthreads(); continue; }
+
+        const unsigned int tileX = tileIdx % hybridCst.tilesX;
+        const unsigned int tileY = tileIdx / hybridCst.tilesX;
+        const int pixelX = tileX * TILE_SIZE + threadIdx.x;
+        const int pixelY = tileY * TILE_SIZE + threadIdx.y;
+        const bool validPixel = (pixelX < hybridCst.screenWidth && pixelY < hybridCst.screenHeight);
+
+        // Load one batch of entities into shared memory
+        const unsigned int entityStart = d_tile_offsets[tileIdx];
+        const unsigned int entityCount = d_tile_offsets[tileIdx + 1] - entityStart;
+        const unsigned int localIdx = threadIdx.y * TILE_SIZE + threadIdx.x;
         if (localIdx < SHARED_BATCH) {
             unsigned int entityIdx = batchStart + localIdx;
             if (entityIdx < entityCount) {
                 unsigned long long pair = d_tile_entity_pairs_sorted[entityStart + entityIdx];
                 unsigned int sphereIndex = (unsigned int)(pair & 0xFFFFFFFFu);
-                glm::vec4 posR = d_spheres[sphereIndex];
-                shPosR[localIdx] = posR;
+                shPosR[localIdx] = d_spheres[sphereIndex];
             }
         }
         __syncthreads();
 
-        unsigned int batchCount = min(SHARED_BATCH, entityCount - batchStart);
-        for (unsigned int i = 0; i < batchCount; i++) {
-            
-            glm::vec4 posR = shPosR[i];
-            float t = iSphereTiled(hybridCst.cameraPos, rd, glm::vec3(posR), posR.w);
-            if (t > 0.0f) {
-                glm::vec3 hit = ray * t;
-                float proj22 = hybridCst.proj[2][2];
-                float proj32 = hybridCst.proj[3][2];
-                float depth = __fdividef(fmaf(hit.z, proj22, proj32), -hit.z);
-                if (depth < minDepth) {
-                    minDepth = depth;
-                    hasHit = true;
-                    glm::vec3 worldHit = hybridCst.cameraPos + rd * t;
-                    glm::vec3 normal = glm::normalize(worldHit - glm::vec3(posR));
-                    float lambert = fmaxf(0.0f, glm::dot(normal, -glm::normalize(rd * t)));
-                    finalColor = glm::vec3(atomsColor[0], atomsColor[1], atomsColor[2]) * lambert * diffuse;
+        // Ray-trace this single batch; atomicMin for depth since multiple blocks share the tile
+        if (validPixel) {
+            glm::vec3 rd  = computeRayDirTiled(pixelX, pixelY, fovTan, halfFovTan);
+            glm::vec3 ray = hybridCst.rayStart + (float)pixelX * hybridCst.dx + (float)pixelY * hybridCst.dy;
+            const int pixelIdx = pixelY * hybridCst.screenWidth + pixelX;
+
+            for (unsigned int i = 0; i < batchCount; i++) {
+                glm::vec4 posR = shPosR[i];
+                float t = iSphereTiled(hybridCst.cameraPos, rd, glm::vec3(posR), posR.w);
+                if (t > 0.0f) {
+                    glm::vec3 hit = ray * t;
+                    float depth = __fdividef(fmaf(hit.z, proj22, proj32), -hit.z);
+                    unsigned int depthU = __float_as_uint(depth);
+                    unsigned int old = atomicMin(&depthBuffer[pixelIdx], depthU);
+                    if (depthU < old) {
+                        glm::vec3 worldHit = hybridCst.cameraPos + rd * t;
+                        glm::vec3 normal = glm::normalize(worldHit - glm::vec3(posR));
+                        float lambert = fmaxf(0.0f, glm::dot(normal, -glm::normalize(rd * t)));
+                        glm::vec3 color = glm::vec3(atomsColor[0], atomsColor[1], atomsColor[2]) * lambert * diffuse;
+                        uchar4 pixel = make_uchar4(
+                            (unsigned char)(color.x * 255.0f),
+                            (unsigned char)(color.y * 255.0f),
+                            (unsigned char)(color.z * 255.0f), 255);
+                        surf2Dwrite(pixel, outputImage, pixelX * sizeof(uchar4), pixelY);
+                    }
                 }
             }
         }
         __syncthreads();
-    }
-
-    if (hasHit) {
-        int pixelIdx = pixelY * hybridCst.screenWidth + pixelX;
-        unsigned int depthU = __float_as_uint(minDepth);
-        depthBuffer[pixelIdx] = depthU;
-        uchar4 pixel = make_uchar4(
-            (unsigned char)(finalColor.x * 255.0f),
-            (unsigned char)(finalColor.y * 255.0f),
-            (unsigned char)(finalColor.z * 255.0f), 255);
-        surf2Dwrite(pixel, outputImage, pixelX * sizeof(uchar4), pixelY);
-        
     }
 }
 
@@ -182,42 +345,169 @@ __device__ inline glm::vec4 iCylinderTiled(const glm::vec3& ro, const glm::vec3&
     return glm::vec4(-1.0f);
 }
 
-__global__ void tiledCylinderRasterBinningKernel(
+/** Light cylinder kernel: persistent threads, 1 tile per work-steal. No atomicMin. */
+__global__ void lightCylinderRasterKernel(
     const Cylinder* __restrict__ d_cylinders,
     const unsigned int* __restrict__ d_tile_offsets,
     const unsigned long long* __restrict__ d_tile_entity_pairs_sorted,
+    const unsigned int* __restrict__ d_lightTileList,
+    const unsigned int* __restrict__ d_tileClassifyCounts,
     unsigned int* __restrict__ depthBuffer,
     cudaSurfaceObject_t outputImage)
 {
-    const unsigned int tileX = blockIdx.x;
-    const unsigned int tileY = blockIdx.y;
-    const unsigned int tileIdx = tileY * hybridCst.tilesX + tileX;
-    const int pixelX = tileX * TILE_SIZE + threadIdx.x;
-    const int pixelY = tileY * TILE_SIZE + threadIdx.y;
-    if (pixelX >= hybridCst.screenWidth || pixelY >= hybridCst.screenHeight) return;
+    const float aspectRatio = (float)hybridCst.screenWidth / (float)hybridCst.screenHeight;
+    const float fovRad = glm::radians(hybridCst.fov);
+    const float fovTan = tanf(fovRad * 0.5f);
+    const float halfFovTan = fovTan * aspectRatio;
+    const float proj22 = hybridCst.proj[2][2];
+    const float proj32 = hybridCst.proj[3][2];
 
-    const unsigned int entityStart = d_tile_offsets[tileIdx];
-    const unsigned int entityEnd = d_tile_offsets[tileIdx + 1];
-    const unsigned int entityCount = entityEnd - entityStart;
-    if (entityCount == 0) return;
-
+    __shared__ unsigned int s_workIdx;
     __shared__ glm::vec4 shPa[SHARED_BATCH], shPb[SHARED_BATCH];
 
-    float aspectRatio = (float)hybridCst.screenWidth / (float)hybridCst.screenHeight;
-    float fovRad = glm::radians(hybridCst.fov);
-    float fovTan = tanf(fovRad * 0.5f);
-    float halfFovTan = fovTan * aspectRatio;
-    glm::vec3 rd = computeRayDirTiled(pixelX, pixelY, fovTan, halfFovTan);
-    float minDepth = __uint_as_float(depthBuffer[pixelY * hybridCst.screenWidth + pixelX]);
-    glm::vec3 finalColor(0.0f);
-    bool hasHit = false;
+    const unsigned int totalLightTiles = d_tileClassifyCounts[0];
 
-    glm::vec3 ray = hybridCst.rayStart + (float)pixelX * hybridCst.dx + (float)pixelY * hybridCst.dy;
+    while (true) {
+        if (threadIdx.x == 0 && threadIdx.y == 0) {
+            s_workIdx = atomicAdd(&g_nextLightWorkItem, 1u);
+        }
+        __syncthreads();
 
-    unsigned int numBatches = (entityCount + SHARED_BATCH - 1) / SHARED_BATCH;
-    for (unsigned int batch = 0; batch < numBatches; batch++) {
-        unsigned int batchStart = batch * SHARED_BATCH;
-        unsigned int localIdx = threadIdx.y * TILE_SIZE + threadIdx.x;
+        if (s_workIdx >= totalLightTiles) return;
+
+        const unsigned int tileIdx = d_lightTileList[s_workIdx];
+        const unsigned int entityStart = d_tile_offsets[tileIdx];
+        const unsigned int entityEnd   = d_tile_offsets[tileIdx + 1];
+        const unsigned int entityCount = entityEnd - entityStart;
+
+        const unsigned int tileX = tileIdx % hybridCst.tilesX;
+        const unsigned int tileY = tileIdx / hybridCst.tilesX;
+        const int pixelX = tileX * TILE_SIZE + threadIdx.x;
+        const int pixelY = tileY * TILE_SIZE + threadIdx.y;
+        const bool validPixel = (pixelX < hybridCst.screenWidth && pixelY < hybridCst.screenHeight);
+
+        glm::vec3 rd, ray;
+        float minDepth = 1e30f;
+        if (validPixel) {
+            rd  = computeRayDirTiled(pixelX, pixelY, fovTan, halfFovTan);
+            ray = hybridCst.rayStart + (float)pixelX * hybridCst.dx + (float)pixelY * hybridCst.dy;
+            minDepth = __uint_as_float(depthBuffer[pixelY * hybridCst.screenWidth + pixelX]);
+        }
+        glm::vec3 finalColor(0.0f);
+        bool hasHit = false;
+
+        const unsigned int numBatches = (entityCount + SHARED_BATCH - 1) / SHARED_BATCH;
+        for (unsigned int batch = 0; batch < numBatches; batch++) {
+            unsigned int batchStart = batch * SHARED_BATCH;
+            unsigned int localIdx = threadIdx.y * TILE_SIZE + threadIdx.x;
+            if (localIdx < SHARED_BATCH) {
+                unsigned int entityIdx = batchStart + localIdx;
+                if (entityIdx < entityCount) {
+                    unsigned long long pair = d_tile_entity_pairs_sorted[entityStart + entityIdx];
+                    unsigned int cylIndex = (unsigned int)(pair & 0xFFFFFFFFu);
+                    Cylinder cyl = d_cylinders[cylIndex];
+                    shPa[localIdx] = cyl.pa_r;
+                    shPb[localIdx] = cyl.pb_r;
+                }
+            }
+            __syncthreads();
+
+            if (validPixel) {
+                unsigned int batchCount = min(SHARED_BATCH, entityCount - batchStart);
+                for (unsigned int i = 0; i < batchCount; i++) {
+                    glm::vec3 pa = glm::vec3(shPa[i]), pb = glm::vec3(shPb[i]);
+                    float ra = shPa[i].w;
+                    glm::vec4 tnor = iCylinderTiled(hybridCst.cameraPos, rd, pa, pb, ra);
+                    if (tnor.x > 0.0f) {
+                        float t = tnor.x;
+                        glm::vec3 hit = ray * t;
+                        float depth = __fdividef(fmaf(hit.z, proj22, proj32), -hit.z);
+                        if (depth < minDepth) {
+                            minDepth = depth;
+                            hasHit = true;
+                            glm::vec3 normal = glm::normalize(glm::vec3(tnor.y, tnor.z, tnor.w));
+                            float lambert = glm::max(0.0f, glm::dot(normal, -glm::normalize(rd * t)));
+                            finalColor = glm::vec3(bondsColor[0], bondsColor[1], bondsColor[2]) * lambert * diffuse;
+                        }
+                    }
+                }
+            }
+            __syncthreads();
+        }
+
+        if (validPixel && hasHit) {
+            int pixelIdx = pixelY * hybridCst.screenWidth + pixelX;
+            unsigned int depthU = __float_as_uint(minDepth);
+            depthBuffer[pixelIdx] = depthU;
+            uchar4 pixel = make_uchar4(
+                (unsigned char)(finalColor.x * 255.0f),
+                (unsigned char)(finalColor.y * 255.0f),
+                (unsigned char)(finalColor.z * 255.0f), 255);
+            surf2Dwrite(pixel, outputImage, pixelX * sizeof(uchar4), pixelY);
+        }
+        __syncthreads();
+    }
+}
+
+/** Heavy cylinder kernel: persistent threads, 1 batch per work-steal. atomicMin depth. */
+__global__ void heavyCylinderRasterKernel(
+    const Cylinder* __restrict__ d_cylinders,
+    const unsigned int* __restrict__ d_tile_offsets,
+    const unsigned long long* __restrict__ d_tile_entity_pairs_sorted,
+    const unsigned int* __restrict__ d_heavyTileIndices,
+    const unsigned int* __restrict__ d_heavyBatchStarts,
+    const unsigned int* __restrict__ d_tileClassifyCounts,
+    unsigned int* __restrict__ depthBuffer,
+    cudaSurfaceObject_t outputImage)
+{
+    const float aspectRatio = (float)hybridCst.screenWidth / (float)hybridCst.screenHeight;
+    const float fovRad = glm::radians(hybridCst.fov);
+    const float fovTan = tanf(fovRad * 0.5f);
+    const float halfFovTan = fovTan * aspectRatio;
+    const float proj22 = hybridCst.proj[2][2];
+    const float proj32 = hybridCst.proj[3][2];
+
+    __shared__ unsigned int s_workIdx;
+    __shared__ unsigned int s_tileIdx;
+    __shared__ unsigned int s_batchStart;
+    __shared__ unsigned int s_batchCount;
+    __shared__ glm::vec4 shPa[SHARED_BATCH], shPb[SHARED_BATCH];
+
+    const unsigned int totalHeavyWorkItems = d_tileClassifyCounts[1];
+
+    while (true) {
+        if (threadIdx.x == 0 && threadIdx.y == 0) {
+            s_workIdx = atomicAdd(&g_nextHeavyWorkItem, 1u);
+        }
+        __syncthreads();
+
+        if (s_workIdx >= totalHeavyWorkItems) return;
+
+        if (threadIdx.x == 0 && threadIdx.y == 0) {
+            unsigned int tileIdx = d_heavyTileIndices[s_workIdx];
+            unsigned int bStart  = d_heavyBatchStarts[s_workIdx];
+            unsigned int entityCount = d_tile_offsets[tileIdx + 1] - d_tile_offsets[tileIdx];
+            s_tileIdx    = tileIdx;
+            s_batchStart = bStart;
+            s_batchCount = min((unsigned int)SHARED_BATCH, entityCount - min(bStart, entityCount));
+        }
+        __syncthreads();
+
+        const unsigned int tileIdx    = s_tileIdx;
+        const unsigned int batchStart = s_batchStart;
+        const unsigned int batchCount = s_batchCount;
+
+        if (batchCount == 0) { __syncthreads(); continue; }
+
+        const unsigned int tileX = tileIdx % hybridCst.tilesX;
+        const unsigned int tileY = tileIdx / hybridCst.tilesX;
+        const int pixelX = tileX * TILE_SIZE + threadIdx.x;
+        const int pixelY = tileY * TILE_SIZE + threadIdx.y;
+        const bool validPixel = (pixelX < hybridCst.screenWidth && pixelY < hybridCst.screenHeight);
+
+        const unsigned int entityStart = d_tile_offsets[tileIdx];
+        const unsigned int entityCount = d_tile_offsets[tileIdx + 1] - entityStart;
+        const unsigned int localIdx = threadIdx.y * TILE_SIZE + threadIdx.x;
         if (localIdx < SHARED_BATCH) {
             unsigned int entityIdx = batchStart + localIdx;
             if (entityIdx < entityCount) {
@@ -230,40 +520,47 @@ __global__ void tiledCylinderRasterBinningKernel(
         }
         __syncthreads();
 
-        unsigned int batchCount = min(SHARED_BATCH, entityCount - batchStart);
-        glm::vec2 pixelCenter((float)pixelX + 0.5f, (float)pixelY + 0.5f);
-        for (unsigned int i = 0; i < batchCount; i++) {
-            
-            glm::vec3 pa = glm::vec3(shPa[i]), pb = glm::vec3(shPb[i]);
-            float ra = shPa[i].w;
-            glm::vec4 tnor = iCylinderTiled(hybridCst.cameraPos, rd, pa, pb, ra);
-            if (tnor.x > 0.0f) {
-                float t = tnor.x;
-                glm::vec3 hit = ray * t;
-                float depth = __fdividef(fmaf(hit.z, hybridCst.proj[2][2], hybridCst.proj[3][2]), -hit.z);
+        if (validPixel) {
+            glm::vec3 rd  = computeRayDirTiled(pixelX, pixelY, fovTan, halfFovTan);
+            glm::vec3 ray = hybridCst.rayStart + (float)pixelX * hybridCst.dx + (float)pixelY * hybridCst.dy;
+            const int pixelIdx = pixelY * hybridCst.screenWidth + pixelX;
 
-                if (depth < minDepth) {
-                    minDepth = depth;
-                    hasHit = true;
-                    glm::vec3 normal = glm::normalize(glm::vec3(tnor.y, tnor.z, tnor.w));
-                    float lambert = glm::max(0.0f, glm::dot(normal, -glm::normalize(rd * t)));
-                    finalColor = glm::vec3(bondsColor[0], bondsColor[1], bondsColor[2]) * lambert * diffuse;
+            for (unsigned int i = 0; i < batchCount; i++) {
+                glm::vec3 pa = glm::vec3(shPa[i]), pb = glm::vec3(shPb[i]);
+                float ra = shPa[i].w;
+                glm::vec4 tnor = iCylinderTiled(hybridCst.cameraPos, rd, pa, pb, ra);
+                if (tnor.x > 0.0f) {
+                    float t = tnor.x;
+                    glm::vec3 hit = ray * t;
+                    float depth = __fdividef(fmaf(hit.z, proj22, proj32), -hit.z);
+                    unsigned int depthU = __float_as_uint(depth);
+                    unsigned int old = atomicMin(&depthBuffer[pixelIdx], depthU);
+                    if (depthU < old) {
+                        glm::vec3 normal = glm::normalize(glm::vec3(tnor.y, tnor.z, tnor.w));
+                        float lambert = glm::max(0.0f, glm::dot(normal, -glm::normalize(rd * t)));
+                        glm::vec3 color = glm::vec3(bondsColor[0], bondsColor[1], bondsColor[2]) * lambert * diffuse;
+                        uchar4 pixel = make_uchar4(
+                            (unsigned char)(color.x * 255.0f),
+                            (unsigned char)(color.y * 255.0f),
+                            (unsigned char)(color.z * 255.0f), 255);
+                        surf2Dwrite(pixel, outputImage, pixelX * sizeof(uchar4), pixelY);
+                    }
                 }
             }
         }
         __syncthreads();
     }
+}
 
-    if (hasHit) {
-        int pixelIdx = pixelY * hybridCst.screenWidth + pixelX;
-        unsigned int depthU = __float_as_uint(minDepth);
-        depthBuffer[pixelIdx] = depthU;
-        uchar4 pixel = make_uchar4(
-            (unsigned char)(finalColor.x * 255.0f),
-            (unsigned char)(finalColor.y * 255.0f),
-            (unsigned char)(finalColor.z * 255.0f), 255);
-        surf2Dwrite(pixel, outputImage, pixelX * sizeof(uchar4), pixelY);
+// Helper: query SM count (cached)
+static int getNumSMs() {
+    static int numSMs = 0;
+    if (numSMs == 0) {
+        int device = 0;
+        cudaGetDevice(&device);
+        cudaDeviceGetAttribute(&numSMs, cudaDevAttrMultiProcessorCount, device);
     }
+    return numSMs;
 }
 
 extern "C" void launchTiledSphereRasterBinning(
@@ -274,12 +571,47 @@ extern "C" void launchTiledSphereRasterBinning(
     cudaSurfaceObject_t outputImage,
     unsigned int tilesX,
     unsigned int tilesY,
+    unsigned int* d_lightTileList,
+    unsigned int* d_heavyTileIndices,
+    unsigned int* d_heavyBatchStarts,
+    unsigned int* d_tileClassifyCounts,
     cudaStream_t stream)
 {
+    unsigned int totalTiles = tilesX * tilesY;
+
+    // Classify tiles into light and heavy lists
+    cudaMemsetAsync(d_tileClassifyCounts, 0, 2 * sizeof(unsigned int), stream);
+    {
+        int threads = 256;
+        int blocks = (totalTiles + threads - 1) / threads;
+        classifyTilesKernel<<<blocks, threads, 0, stream>>>(
+            d_tile_offsets, d_lightTileList, d_heavyTileIndices,
+            d_heavyBatchStarts, d_tileClassifyCounts, totalTiles);
+    }
+
+    int numSMs = getNumSMs();
     dim3 block(TILE_SIZE, TILE_SIZE);
-    dim3 grid(tilesX, tilesY);
-    tiledSphereRasterBinningKernel<<<grid, block, 0, stream>>>(
-        d_spheres, d_tile_offsets, d_tile_entity_pairs_sorted, d_depthBuffer, outputImage);
+    dim3 grid(numSMs * 2, 1);
+
+    // Light tiles: persistent threads, 1 tile per work-steal (no atomicMin)
+    {
+        unsigned int zero = 0;
+        cudaMemcpyToSymbolAsync(g_nextLightWorkItem, &zero, sizeof(unsigned int), 0, cudaMemcpyHostToDevice, stream);
+        lightSphereRasterKernel<<<grid, block, 0, stream>>>(
+            d_spheres, d_tile_offsets, d_tile_entity_pairs_sorted,
+            d_lightTileList, d_tileClassifyCounts,
+            d_depthBuffer, outputImage);
+    }
+
+    // Heavy tiles: persistent threads, 1 batch per work-steal (atomicMin depth)
+    {
+        unsigned int zero = 0;
+        cudaMemcpyToSymbolAsync(g_nextHeavyWorkItem, &zero, sizeof(unsigned int), 0, cudaMemcpyHostToDevice, stream);
+        heavySphereRasterKernel<<<grid, block, 0, stream>>>(
+            d_spheres, d_tile_offsets, d_tile_entity_pairs_sorted,
+            d_heavyTileIndices, d_heavyBatchStarts, d_tileClassifyCounts,
+            d_depthBuffer, outputImage);
+    }
 }
 
 extern "C" void launchTiledCylinderRasterBinning(
@@ -290,10 +622,42 @@ extern "C" void launchTiledCylinderRasterBinning(
     cudaSurfaceObject_t outputImage,
     unsigned int tilesX,
     unsigned int tilesY,
+    unsigned int* d_lightTileList,
+    unsigned int* d_heavyTileIndices,
+    unsigned int* d_heavyBatchStarts,
+    unsigned int* d_tileClassifyCounts,
     cudaStream_t stream)
 {
+    unsigned int totalTiles = tilesX * tilesY;
+
+    cudaMemsetAsync(d_tileClassifyCounts, 0, 2 * sizeof(unsigned int), stream);
+    {
+        int threads = 256;
+        int blocks = (totalTiles + threads - 1) / threads;
+        classifyTilesKernel<<<blocks, threads, 0, stream>>>(
+            d_tile_offsets, d_lightTileList, d_heavyTileIndices,
+            d_heavyBatchStarts, d_tileClassifyCounts, totalTiles);
+    }
+
+    int numSMs = getNumSMs();
     dim3 block(TILE_SIZE, TILE_SIZE);
-    dim3 grid(tilesX, tilesY);
-    tiledCylinderRasterBinningKernel<<<grid, block, 0, stream>>>(
-        d_cylinders, d_tile_offsets, d_tile_entity_pairs_sorted, d_depthBuffer, outputImage);
+    dim3 grid(numSMs * 2, 1);
+
+    {
+        unsigned int zero = 0;
+        cudaMemcpyToSymbolAsync(g_nextLightWorkItem, &zero, sizeof(unsigned int), 0, cudaMemcpyHostToDevice, stream);
+        lightCylinderRasterKernel<<<grid, block, 0, stream>>>(
+            d_cylinders, d_tile_offsets, d_tile_entity_pairs_sorted,
+            d_lightTileList, d_tileClassifyCounts,
+            d_depthBuffer, outputImage);
+    }
+
+    {
+        unsigned int zero = 0;
+        cudaMemcpyToSymbolAsync(g_nextHeavyWorkItem, &zero, sizeof(unsigned int), 0, cudaMemcpyHostToDevice, stream);
+        heavyCylinderRasterKernel<<<grid, block, 0, stream>>>(
+            d_cylinders, d_tile_offsets, d_tile_entity_pairs_sorted,
+            d_heavyTileIndices, d_heavyBatchStarts, d_tileClassifyCounts,
+            d_depthBuffer, outputImage);
+    }
 }

--- a/kernels/hybrid_binning/tiled_raster_binning.cu
+++ b/kernels/hybrid_binning/tiled_raster_binning.cu
@@ -29,11 +29,8 @@ __device__ inline float iSphereTiled(const glm::vec3& ro, const glm::vec3& rd,
     return -b - sqrtf(h);
 }
 
-__device__ inline glm::vec3 computeRayDirTiled(int px, int py, float fovTan, float halfFovTan) {
-    glm::vec2 p = (-glm::vec2(hybridCst.screenWidth, hybridCst.screenHeight) +
-                   2.0f * glm::vec2(px, py)) / glm::vec2(hybridCst.screenWidth, hybridCst.screenHeight);
-    return glm::normalize(p.x * hybridCst.right * halfFovTan +
-                          p.y * hybridCst.up * fovTan + hybridCst.front);
+__device__ inline glm::vec3 fastNormalize(const glm::vec3& v) {
+    return v * rsqrtf(glm::dot(v, v));
 }
 
 __device__ inline glm::vec4 iCylinderTiled(const glm::vec3& ro, const glm::vec3& rd,
@@ -100,7 +97,7 @@ __device__ inline void writeFragmentSafe(
     cudaSurfaceObject_t outputImage, int px, int py)
 {
     unsigned int newDepth = __float_as_uint(depth);
-    unsigned int old = depthBuffer[pixelIdx];
+    unsigned int old = __ldg(&depthBuffer[pixelIdx]);
 
     while (__uint_as_float(old) > depth) {
         unsigned int assumed = old;
@@ -128,19 +125,15 @@ __global__ void tiledSphereRasterWGKernel(
     unsigned int* __restrict__ depthBuffer,
     cudaSurfaceObject_t outputImage)
 {
-    const float aspectRatio = (float)hybridCst.screenWidth / (float)hybridCst.screenHeight;
-    const float fovRad = glm::radians(hybridCst.fov);
-    const float fovTan = tanf(fovRad * 0.5f);
-    const float halfFovTan = fovTan * aspectRatio;
     const float proj22 = hybridCst.proj[2][2];
     const float proj32 = hybridCst.proj[3][2];
 
     __shared__ glm::vec4 shPosR[SHARED_BATCH];
 
     const unsigned int wgIdx       = blockIdx.x;
-    const unsigned int tileIdx     = d_wg_tileId[wgIdx];
-    const unsigned int entityStart = d_wg_entityStart[wgIdx];
-    const unsigned int entityCount = d_wg_entityCount[wgIdx];
+    const unsigned int tileIdx     = __ldg(&d_wg_tileId[wgIdx]);
+    const unsigned int entityStart = __ldg(&d_wg_entityStart[wgIdx]);
+    const unsigned int entityCount = __ldg(&d_wg_entityCount[wgIdx]);
 
     const unsigned int tileX  = tileIdx % hybridCst.tilesX;
     const unsigned int tileY  = tileIdx / hybridCst.tilesX;
@@ -150,7 +143,7 @@ __global__ void tiledSphereRasterWGKernel(
 
     bool hasHit = false;
     glm::vec3 finalColor = glm::vec3(0.0f);
-    float finalDepth = __uint_as_float(depthBuffer[pixelY * hybridCst.screenWidth + pixelX]);
+    float finalDepth = __uint_as_float(__ldg(&depthBuffer[pixelY * hybridCst.screenWidth + pixelX]));
 
     // Load entities into shared memory
     const unsigned int localIdx = threadIdx.y * TILE_SIZE + threadIdx.x;
@@ -164,8 +157,8 @@ __global__ void tiledSphereRasterWGKernel(
     // Ray-trace; atomicMin since multiple blocks may share a tile
     if (!validPixel) return;
 
-    glm::vec3 rd  = computeRayDirTiled(pixelX, pixelY, fovTan, halfFovTan);
     glm::vec3 ray = hybridCst.rayStart + (float)pixelX * hybridCst.dx + (float)pixelY * hybridCst.dy;
+    glm::vec3 rd  = fastNormalize(ray.x * hybridCst.right + ray.y * hybridCst.up - ray.z * hybridCst.front);
     const int pixelIdx = pixelY * hybridCst.screenWidth + pixelX;
 
     for (unsigned int i = 0; i < entityCount; i++) {
@@ -177,9 +170,8 @@ __global__ void tiledSphereRasterWGKernel(
             
             if (depth < finalDepth) {
                 hasHit = true;
-                glm::vec3 worldHit = hybridCst.cameraPos + rd * t;
-                glm::vec3 normal = glm::normalize(worldHit - glm::vec3(posR));
-                float lambert = fmaxf(0.0f, glm::dot(normal, -glm::normalize(rd * t)));
+                glm::vec3 normal = fastNormalize(hybridCst.cameraPos + rd * t - glm::vec3(posR));
+                float lambert = fmaxf(0.0f, glm::dot(normal, -rd));
                 finalColor = glm::vec3(atomsColor[0], atomsColor[1], atomsColor[2]) * lambert * diffuse;
                 finalDepth = depth;
             }
@@ -205,20 +197,15 @@ __global__ void tiledCylinderRasterWGKernel(
     unsigned int* __restrict__ depthBuffer,
     cudaSurfaceObject_t outputImage)
 {
-    const float aspectRatio = (float)hybridCst.screenWidth / (float)hybridCst.screenHeight;
-    const float fovRad = glm::radians(hybridCst.fov);
-    const float fovTan = tanf(fovRad * 0.5f);
-    const float halfFovTan = fovTan * aspectRatio;
     const float proj22 = hybridCst.proj[2][2];
     const float proj32 = hybridCst.proj[3][2];
 
-    
     __shared__ glm::vec4 shPa[SHARED_BATCH], shPb[SHARED_BATCH];
 
     const unsigned int wgIdx       = blockIdx.x;
-    const unsigned int tileIdx     = d_wg_tileId[wgIdx];
-    const unsigned int entityStart = d_wg_entityStart[wgIdx];
-    const unsigned int entityCount = d_wg_entityCount[wgIdx];
+    const unsigned int tileIdx     = __ldg(&d_wg_tileId[wgIdx]);
+    const unsigned int entityStart = __ldg(&d_wg_entityStart[wgIdx]);
+    const unsigned int entityCount = __ldg(&d_wg_entityCount[wgIdx]);
 
     const unsigned int tileX  = tileIdx % hybridCst.tilesX;
     const unsigned int tileY  = tileIdx / hybridCst.tilesX;
@@ -228,7 +215,7 @@ __global__ void tiledCylinderRasterWGKernel(
     
     bool hasHit = false;
     glm::vec3 finalColor = glm::vec3(0.0f);
-    float finalDepth = __uint_as_float(depthBuffer[pixelY * hybridCst.screenWidth + pixelX]); 
+    float finalDepth = __uint_as_float(__ldg(&depthBuffer[pixelY * hybridCst.screenWidth + pixelX])); 
 
     // Load entities into shared memory
     const unsigned int localIdx = threadIdx.y * TILE_SIZE + threadIdx.x;
@@ -244,8 +231,8 @@ __global__ void tiledCylinderRasterWGKernel(
     // Ray-trace; atomicMin since multiple blocks may share a tile
     if (!validPixel) return;
 
-    glm::vec3 rd  = computeRayDirTiled(pixelX, pixelY, fovTan, halfFovTan);
     glm::vec3 ray = hybridCst.rayStart + (float)pixelX * hybridCst.dx + (float)pixelY * hybridCst.dy;
+    glm::vec3 rd  = fastNormalize(ray.x * hybridCst.right + ray.y * hybridCst.up - ray.z * hybridCst.front);
     const int pixelIdx = pixelY * hybridCst.screenWidth + pixelX;
 
     for (unsigned int i = 0; i < entityCount; i++) {
@@ -259,8 +246,8 @@ __global__ void tiledCylinderRasterWGKernel(
             
             if (depth < finalDepth) {
                 hasHit = true;
-                glm::vec3 normal = glm::normalize(glm::vec3(tnor.y, tnor.z, tnor.w));
-                float lambert = glm::max(0.0f, glm::dot(normal, -glm::normalize(rd * t)));
+                glm::vec3 normal = fastNormalize(glm::vec3(tnor.y, tnor.z, tnor.w));
+                float lambert = fmaxf(0.0f, glm::dot(normal, -rd));
                 finalColor = glm::vec3(bondsColor[0], bondsColor[1], bondsColor[2]) * lambert * diffuse;
                 finalDepth = depth;
             }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Refactors the CUDA tiled raster path for spheres/cylinders and changes depth-buffer write semantics via atomics, which can affect rendering correctness and performance despite being localized to GPU kernels.
> 
> **Overview**
> Switches the hybrid binning tiled rasterization path from per-tile `tileOffsets` dispatch to an *RLE-expanded work-group* dispatch list (splitting each tile’s run into `SHARED_BATCH`-sized work groups) and updates both sphere and cylinder pipelines to launch the new `...RasterWG` kernels.
> 
> Adds new GPU/host buffers to `SphereBinningResources` and `CylinderBinningResources` to store work-group metadata and introduces `launchExpandWorkGroups` plus new unified tiled kernels in `tiled_raster_binning.cu` that load a work group into shared memory and perform depth-tested writes using an `atomicCAS` loop.
> 
> Optimizes small-entity raster kernels by replacing per-pixel FOV-based ray direction computation with a shared ray-basis formulation (`fastNormalize`), uses `__ldg` for index reads, and updates cylinder scanline fill to compute spans without accumulating intersection arrays. Also wires `smallEntityThreshold` into the per-frame pipeline execution loop.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a7942a1fe2f2e068fc2409c4f3b8152f1c578021. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->